### PR TITLE
Use SPM tools version 5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
 
 import PackageDescription
 
@@ -18,7 +18,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
+    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
This fixes the following error:

error: 
```
'package(name:url:from:)' is unavailable
    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     ^~~~~~~
PackageDescription.Package.Dependency:5:24: note: 'package(name:url:from:)' was introduced in PackageDescription 5.2
    public static func package(name: String? = nil, url: String, from version: PackageDescription.Version) -> PackageDescription.Package.Dependency
```

There might be a solution to this error that doesn't involve requiring Swift 5.2 but this is the easiest one. Let me know if you're ok with this fix ☺️.