### PR TITLE
Add support for parsing enum raw string values

### DIFF
--- a/Sources/Parsing/Parsers/Enum.swift
+++ b/Sources/Parsing/Parsers/Enum.swift
@@ -1,0 +1,55 @@
+extension Parsers {
+  /// Parses out the first matching raw value in a list of possible values from the start of the current input.
+  @inlinable
+  public static func enumRawValue<EnumType: RawRepresentable>(
+    in possibleValues: [EnumType]
+  ) -> AnyParser<Substring, EnumType> where EnumType.RawValue == String {
+    OneOfMany(
+      possibleValues.map { value in
+        StartsWith(value.rawValue[...]).map { value }
+      }
+    )
+    .eraseToAnyParser()
+  }
+}
+
+/// Provides an opt-in convenience high-level API for parsing enum values.
+public protocol CaseParsable: RawRepresentable {}
+
+extension CaseParsable where Self.RawValue == String {
+  /// Parses out the first matching raw value from a list of possible values, or returns nil.
+  ///
+  /// Example:
+  ///
+  ///     enum SomeValues: String, CaseParseable {
+  ///         case one
+  ///         case two
+  ///     }
+  ///
+  ///     SomeValues.firstMatchingValue(in: [.one]).parse("one").output // SomeValues.one
+  ///     SomeValues.firstMatchingValue(in: [.two]).parse("one").output // nil
+  ///
+  public static func firstMatchingCase(
+    in possibleValues: [Self]
+  ) -> AnyParser<Substring, Self> {
+    Parsers.enumRawValue(in: possibleValues)
+  }
+}
+
+extension CaseParsable where Self: CaseIterable, Self.RawValue == String {
+  /// Parses out the first matching raw value from all possible cases, or returns nil.
+  ///
+  /// Example:
+  ///
+  ///     enum SomeValues: String, CaseParseable, CaseIterable {
+  ///         case one
+  ///         case two
+  ///     }
+  ///
+  ///     SomeValues.firstMatchingValue.parse("one").output // SomeValues.one
+  ///     SomeValues.firstMatchingValue.parse("six").output // nil
+  ///
+  public static var firstMatchingCase: AnyParser<Substring, Self> {
+    Parsers.enumRawValue(in: allCases as? [Self] ?? [])
+  }
+}

--- a/Tests/ParsingTests/EnumTests.swift
+++ b/Tests/ParsingTests/EnumTests.swift
@@ -1,0 +1,33 @@
+import Parsing
+import XCTest
+
+final class EnumTests: XCTestCase {
+  enum Example: String, CaseIterable, CaseParsable {
+    case one
+    case two
+  }
+
+  func testSuccess() {
+    var input = "one"[...]
+    XCTAssertEqual(.one, Parsers.enumRawValue(in: Example.allCases).parse(&input))
+    XCTAssertEqual("", input)
+  }
+
+  func testFailure() {
+    var input = "one"[...]
+    XCTAssertNil(Parsers.enumRawValue(in: [Example.two]).parse(&input))
+    XCTAssertEqual("one", input)
+  }
+
+  func testCaseParsableWithSpecificCases() {
+    var input = "one"[...]
+    XCTAssertEqual(.one, Example.firstMatchingCase(in: [Example.one]).parse(&input))
+    XCTAssertEqual("", input)
+  }
+
+  func testCaseParsableWithAllCases() {
+    var input = "one"[...]
+    XCTAssertEqual(.one, Example.firstMatchingCase.parse(&input))
+    XCTAssertEqual("", input)
+  }
+}


### PR DESCRIPTION
# Description

This PR adds support for parsing raw enum values off the beginning of `Input` and returning the enum value in the following ways:

* A `Parsers.enumRawValue(in:)` function that returns a parser.
* An opt-in high-level API as extensions on a custom `CaseParsable` protocol that enums can conform to.

## Use case

A common task might be to parse some kind of input into a local domain model which may frequently include some kind of enumerated type. For example, given the following string:

```swift
"thing:type_a:type_b"
```

And the following types:

```swift
struct Thing {
  var type_a: TypeA
  var type_b: TypeB
}

enum TypeA: String, CaseIterable {
  case one
}

enum TypeB: String, CaseIterable {
  case two
}
```

Using the new enum case parser you could construct a `Parser<Substring, Thing>` as follows:

```swift
let thingParser = StartsWith("thing:")
    .take(Parsers.enumRawValue(in: TypeA.allCases))
    .skip(StartsWith(":"))
    .take(Parsers.enumRawValue(in: TypeB.allCases))
    .map(Thing.init(type_a:type_b:))
```

Or, by opting the enums into the `CaseParsable` protocol the above could be rewritten as:

```swift
let thingParser = StartsWith("thing:")
    .take(TypeA.firstMatchingCase)
    .skip(StartsWith(":"))
    .take(TypeB.firstMatchingCase)
    .map(Thing.init(type_a:type_b:))
```

## Discussion

I originally implemented this in a Swift playground purely as an extension on the `RawRepresentable` protocol however I feel like libraries should avoid adding behaviour to built-in types by default and this should be opt-in, which is why the main parsing logic is implemented as a static function on `Parsers` and the high-level API implemented as default implementations on a custom protocol. Conforming to the `CaseParsable` protocol feels like a fairly unobtrusive way to gain extra functionality and is inspired by the similarly named `CaseIterable` protocol.

This PR only adds support for parsing string raw values but could be extended to support other raw value types such as `Int` although I feel like `String` would be the common use-case for this.

Main points for discussion are:

* Is implementing the base parser as a static function the best way of going about this? Because it's entirely constructed by composing existing parsers it felt overkill to create an entirely new `Parser` type. Is there a better approach?
* Naming - naming is hard, do the names of both the static function and `CaseParsable` functions feel right? I like `firstMatchingCase` although I'm not sure if it completely conveys the behaviour (that it works on the prefix of the input). I feel like `enumRawValue` could be named better.