### PR TITLE
Optionally exclude newlines from Whitespace parser

### DIFF
--- a/Sources/Parsing/Parsers/Whitespace.swift
+++ b/Sources/Parsing/Parsers/Whitespace.swift
@@ -5,17 +5,29 @@ where
   Input.SubSequence == Input,
   Input.Element == UTF8.CodeUnit
 {
+  public let includeNewlines: Bool
+
   @inlinable
-  public init() {}
+  public init(includeNewlines: Bool = true) {
+    self.includeNewlines = includeNewlines
+  }
 
   @inlinable
   public func parse(_ input: inout Input) -> Input? {
-    let output = input.prefix(while: { (byte: UTF8.CodeUnit) in
-      byte == .init(ascii: " ")
-        || byte == .init(ascii: "\n")
-        || byte == .init(ascii: "\r")
-        || byte == .init(ascii: "\t")
-    })
+    let output: Output
+    if self.includeNewlines {
+        output = input.prefix(while: { (byte: UTF8.CodeUnit) in
+          byte == .init(ascii: " ")
+            || byte == .init(ascii: "\n")
+            || byte == .init(ascii: "\r")
+            || byte == .init(ascii: "\t")
+        })
+    } else {
+        output = input.prefix(while: { (byte: UTF8.CodeUnit) in
+          byte == .init(ascii: " ")
+            || byte == .init(ascii: "\t")
+        })
+    }
     input.removeFirst(output.count)
     return output
   }

--- a/Tests/ParsingTests/WhitespaceTests.swift
+++ b/Tests/ParsingTests/WhitespaceTests.swift
@@ -13,4 +13,10 @@ final class WhitespaceTests: XCTestCase {
     XCTAssertNotNil(Whitespace().parse(&input))
     XCTAssertEqual("Hello, world!", Substring(input))
   }
+
+  func testExcludesNewlinesWhitespace() {
+    var input = "    \t\t    \r\nHello, world!"[...].utf8
+    XCTAssertNotNil(Whitespace(includeNewlines: false).parse(&input))
+    XCTAssertEqual("\r\nHello, world!", Substring(input))
+  }
 }


### PR DESCRIPTION
Some use-cases need newlines to be excluded from white space. For example if you want to parse Many() of parsers that contain trailing space with Newline() separator. Do you think this would be okay, or should I make a new parser like "Spaces" or "SpacesAndTabs"?