### PR TITLE
Fix in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ let parser = Prefix<Substring> { $0 != "," }
 
 var input = "Hello,World"[...]
 parser.parse(&input) // => "Hello!!!"
-input // => ",Hello"
+input // => ",World"
 ```
 
 The type of this parser is now:


### PR DESCRIPTION
In both examples, "Hello,World" is parsed the same way, therefore the remainders should be equivalent.