### PR TITLE
Add Take parsers up to 11

### DIFF
--- a/Sources/Parsing/Parsers/Take.swift
+++ b/Sources/Parsing/Parsers/Take.swift
@@ -66,6 +66,84 @@ extension Parser {
   where P: Parser, P.Input == Input, Output == (A, B, C, D) {
     .init(self, parser)
   }
+
+  /// Returns a parser that runs this parser and the given parser, returning this parser's outputs
+  /// and the given parser's output in a flattened tuple.
+  ///
+  /// - Parameter parser: A parser to run immediately after this parser.
+  /// - Returns: A parser that runs two parsers, returning both outputs in a flattened tuple.
+  @inlinable
+  public func take<A, B, C, D, E, P>(
+    _ parser: P
+  ) -> Parsers.Take6<Self, A, B, C, D, E, P>
+  where P: Parser, P.Input == Input, Output == (A, B, C, D, E) {
+    .init(self, parser)
+  }
+
+  /// Returns a parser that runs this parser and the given parser, returning this parser's outputs
+  /// and the given parser's output in a flattened tuple.
+  ///
+  /// - Parameter parser: A parser to run immediately after this parser.
+  /// - Returns: A parser that runs two parsers, returning both outputs in a flattened tuple.
+  @inlinable
+  public func take<A, B, C, D, E, F, P>(
+    _ parser: P
+  ) -> Parsers.Take7<Self, A, B, C, D, E, F, P>
+  where P: Parser, P.Input == Input, Output == (A, B, C, D, E, F) {
+    .init(self, parser)
+  }
+
+  /// Returns a parser that runs this parser and the given parser, returning this parser's outputs
+  /// and the given parser's output in a flattened tuple.
+  ///
+  /// - Parameter parser: A parser to run immediately after this parser.
+  /// - Returns: A parser that runs two parsers, returning both outputs in a flattened tuple.
+  @inlinable
+  public func take<A, B, C, D, E, F, G, P>(
+    _ parser: P
+  ) -> Parsers.Take8<Self, A, B, C, D, E, F, G, P>
+  where P: Parser, P.Input == Input, Output == (A, B, C, D, E, F, G) {
+    .init(self, parser)
+  }
+
+  /// Returns a parser that runs this parser and the given parser, returning this parser's outputs
+  /// and the given parser's output in a flattened tuple.
+  ///
+  /// - Parameter parser: A parser to run immediately after this parser.
+  /// - Returns: A parser that runs two parsers, returning both outputs in a flattened tuple.
+  @inlinable
+  public func take<A, B, C, D, E, F, G, H, P>(
+    _ parser: P
+  ) -> Parsers.Take9<Self, A, B, C, D, E, F, G, H, P>
+  where P: Parser, P.Input == Input, Output == (A, B, C, D, E, F, G, H) {
+    .init(self, parser)
+  }
+
+  /// Returns a parser that runs this parser and the given parser, returning this parser's outputs
+  /// and the given parser's output in a flattened tuple.
+  ///
+  /// - Parameter parser: A parser to run immediately after this parser.
+  /// - Returns: A parser that runs two parsers, returning both outputs in a flattened tuple.
+  @inlinable
+  public func take<A, B, C, D, E, F, G, H, I, P>(
+    _ parser: P
+  ) -> Parsers.Take10<Self, A, B, C, D, E, F, G, H, I, P>
+  where P: Parser, P.Input == Input, Output == (A, B, C, D, E, F, G, H, I) {
+    .init(self, parser)
+  }
+
+  /// Returns a parser that runs this parser and the given parser, returning this parser's outputs
+  /// and the given parser's output in a flattened tuple.
+  ///
+  /// - Parameter parser: A parser to run immediately after this parser.
+  /// - Returns: A parser that runs two parsers, returning both outputs in a flattened tuple.
+  @inlinable
+  public func take<A, B, C, D, E, F, G, H, I, J, P>(
+    _ parser: P
+  ) -> Parsers.Take11<Self, A, B, C, D, E, F, G, H, I, J, P>
+  where P: Parser, P.Input == Input, Output == (A, B, C, D, E, F, G, H, I, J) {
+    .init(self, parser)
+  }
 }
 
 extension Parsers {
@@ -201,6 +279,216 @@ extension Parsers {
         return nil
       }
       return (a, b, c, d, e)
+    }
+  }
+
+  /// A parser that runs a parser of a tuple of outputs and another parser, one after the other,
+  /// and returns a flattened tuple of the first parser's outputs and the second parser's output.
+  public struct Take6<ABCDE, A, B, C, D, E, F>: Parser
+  where
+    ABCDE: Parser,
+    ABCDE.Output == (A, B, C, D, E),
+    F: Parser,
+    ABCDE.Input == F.Input
+  {
+    public let abcde: ABCDE
+    public let f: F
+
+    @inlinable
+    public init(
+      _ abcde: ABCDE,
+      _ f: F
+    ) {
+      self.abcde = abcde
+      self.f = f
+    }
+
+    @inlinable
+    public func parse(_ input: inout ABCDE.Input) -> (A, B, C, D, E, F.Output)? {
+      let original = input
+      guard let (a, b, c, d, e) = self.abcde.parse(&input)
+      else { return nil }
+      guard let f = self.f.parse(&input)
+      else {
+        input = original
+        return nil
+      }
+      return (a, b, c, d, e, f)
+    }
+  }
+
+  /// A parser that runs a parser of a tuple of outputs and another parser, one after the other,
+  /// and returns a flattened tuple of the first parser's outputs and the second parser's output.
+  public struct Take7<ABCDEF, A, B, C, D, E, F, G>: Parser
+  where
+    ABCDEF: Parser,
+    ABCDEF.Output == (A, B, C, D, E, F),
+    G: Parser,
+    ABCDEF.Input == G.Input
+  {
+    public let abcdef: ABCDEF
+    public let g: G
+
+    @inlinable
+    public init(
+      _ abcdef: ABCDEF,
+      _ g: G
+    ) {
+      self.abcdef = abcdef
+      self.g = g
+    }
+
+    @inlinable
+    public func parse(_ input: inout ABCDEF.Input) -> (A, B, C, D, E, F, G.Output)? {
+      let original = input
+      guard let (a, b, c, d, e, f) = self.abcdef.parse(&input)
+      else { return nil }
+      guard let g = self.g.parse(&input)
+      else {
+        input = original
+        return nil
+      }
+      return (a, b, c, d, e, f, g)
+    }
+  }
+
+  /// A parser that runs a parser of a tuple of outputs and another parser, one after the other,
+  /// and returns a flattened tuple of the first parser's outputs and the second parser's output.
+  public struct Take8<ABCDEFG, A, B, C, D, E, F, G, H>: Parser
+  where
+    ABCDEFG: Parser,
+    ABCDEFG.Output == (A, B, C, D, E, F, G),
+    H: Parser,
+    ABCDEFG.Input == H.Input
+  {
+    public let abcdefg: ABCDEFG
+    public let h: H
+
+    @inlinable
+    public init(
+      _ abcdefg: ABCDEFG,
+      _ h: H
+    ) {
+      self.abcdefg = abcdefg
+      self.h = h
+    }
+
+    @inlinable
+    public func parse(_ input: inout ABCDEFG.Input) -> (A, B, C, D, E, F, G, H.Output)? {
+      let original = input
+      guard let (a, b, c, d, e, f, g) = self.abcdefg.parse(&input)
+      else { return nil }
+      guard let h = self.h.parse(&input)
+      else {
+        input = original
+        return nil
+      }
+      return (a, b, c, d, e, f, g, h)
+    }
+  }
+
+  /// A parser that runs a parser of a tuple of outputs and another parser, one after the other,
+  /// and returns a flattened tuple of the first parser's outputs and the second parser's output.
+  public struct Take9<ABCDEFGH, A, B, C, D, E, F, G, H, I>: Parser
+  where
+    ABCDEFGH: Parser,
+    ABCDEFGH.Output == (A, B, C, D, E, F, G, H),
+    I: Parser,
+    ABCDEFGH.Input == I.Input
+  {
+    public let abcdefgh: ABCDEFGH
+    public let i: I
+
+    @inlinable
+    public init(
+      _ abcdefgh: ABCDEFGH,
+      _ i: I
+    ) {
+      self.abcdefgh = abcdefgh
+      self.i = i
+    }
+
+    @inlinable
+    public func parse(_ input: inout ABCDEFGH.Input) -> (A, B, C, D, E, F, G, H, I.Output)? {
+      let original = input
+      guard let (a, b, c, d, e, f, g, h) = self.abcdefgh.parse(&input)
+      else { return nil }
+      guard let i = self.i.parse(&input)
+      else {
+        input = original
+        return nil
+      }
+      return (a, b, c, d, e, f, g, h, i)
+    }
+  }
+
+  /// A parser that runs a parser of a tuple of outputs and another parser, one after the other,
+  /// and returns a flattened tuple of the first parser's outputs and the second parser's output.
+  public struct Take10<ABCDEFGHI, A, B, C, D, E, F, G, H, I, J>: Parser
+  where
+    ABCDEFGHI: Parser,
+    ABCDEFGHI.Output == (A, B, C, D, E, F, G, H, I),
+    J: Parser,
+    ABCDEFGHI.Input == J.Input
+  {
+    public let abcdefghi: ABCDEFGHI
+    public let j: J
+
+    @inlinable
+    public init(
+      _ abcdefghi: ABCDEFGHI,
+      _ j: J
+    ) {
+      self.abcdefghi = abcdefghi
+      self.j = j
+    }
+
+    @inlinable
+    public func parse(_ input: inout ABCDEFGHI.Input) -> (A, B, C, D, E, F, G, H, I, J.Output)? {
+      let original = input
+      guard let (a, b, c, d, e, f, g, h, i) = self.abcdefghi.parse(&input)
+      else { return nil }
+      guard let j = self.j.parse(&input)
+      else {
+        input = original
+        return nil
+      }
+      return (a, b, c, d, e, f, g, h, i, j)
+    }
+  }
+
+  /// A parser that runs a parser of a tuple of outputs and another parser, one after the other,
+  /// and returns a flattened tuple of the first parser's outputs and the second parser's output.
+  public struct Take11<ABCDEFGHIJ, A, B, C, D, E, F, G, H, I, J, K>: Parser
+  where
+    ABCDEFGHIJ: Parser,
+    ABCDEFGHIJ.Output == (A, B, C, D, E, F, G, H, I, J),
+    K: Parser,
+    ABCDEFGHIJ.Input == K.Input
+  {
+    public let abcdefghij: ABCDEFGHIJ
+    public let k: K
+
+    @inlinable
+    public init(
+      _ abcdefghij: ABCDEFGHIJ,
+      _ k: K
+    ) {
+      self.abcdefghij = abcdefghij
+      self.k = k
+    }
+
+    @inlinable
+    public func parse(_ input: inout ABCDEFGHIJ.Input) -> (A, B, C, D, E, F, G, H, I, J, K.Output)? {
+      let original = input
+      guard let (a, b, c, d, e, f, g, h, i, j) = self.abcdefghij.parse(&input)
+      else { return nil }
+      guard let k = self.k.parse(&input)
+      else {
+        input = original
+        return nil
+      }
+      return (a, b, c, d, e, f, g, h, i, j, k)
     }
   }
 }

--- a/Tests/ParsingTests/TakeTests.swift
+++ b/Tests/ParsingTests/TakeTests.swift
@@ -29,4 +29,97 @@ final class TakeTests: XCTestCase {
         == XCTUnwrap(First().take(First()).take(First()).take(First()).take(First()).parse(&input)))
     XCTAssertEqual("", input)
   }
+
+  func testTake6Success() {
+    var input = "123456"[...]
+    let first5 = First<Substring>().take(First()).take(First()).take(First()).take(First())
+    let parser = first5.take(First())
+    XCTAssert(
+      try ("1", "2", "3", "4", "5", "6")
+        == XCTUnwrap(parser.parse(&input)))
+    XCTAssertEqual("", input)
+  }
+
+  func testTake7Success() {
+    var input = "1234567"[...]
+    let first5 = First<Substring>().take(First()).take(First()).take(First()).take(First())
+    let parser = first5.take(First()).take(First())
+    XCTAssert(
+      try ("1", "2", "3", "4", "5", "6", "7")
+        == XCTUnwrap(parser.parse(&input)))
+    XCTAssertEqual("", input)
+  }
+
+  func testTake8Success() {
+    var input = "12345678"[...]
+    let first5 = First<Substring>().take(First()).take(First()).take(First()).take(First())
+    let parser = first5.take(First()).take(First()).take(First())
+    XCTAssert(
+      try ("1", "2", "3", "4", "5", "6", "7", "8")
+        == XCTUnwrap(parser.parse(&input)))
+    XCTAssertEqual("", input)
+  }
+
+  func testTake9Success() {
+    var input = "123456789"[...]
+    let first5 = First<Substring>().take(First()).take(First()).take(First()).take(First())
+    let parser = first5.take(First()).take(First()).take(First()).take(First())
+    XCTAssert(
+      try ("1", "2", "3", "4", "5", "6", "7", "8", "9")
+        == XCTUnwrap(parser.parse(&input)))
+    XCTAssertEqual("", input)
+  }
+
+  func testTake10Success() {
+    var input = "1234567890"[...]
+    let first5 = First<Substring>().take(First()).take(First()).take(First()).take(First())
+    let parser = first5.take(First()).take(First()).take(First()).take(First()).take(First())
+    XCTAssert(
+      try ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
+        == XCTUnwrap(parser.parse(&input)))
+    XCTAssertEqual("", input)
+  }
+
+  func testTake11Success() {
+    var input = "1234567890A"[...]
+    let first5 = First<Substring>().take(First()).take(First()).take(First()).take(First())
+    let first10 = first5.take(First()).take(First()).take(First()).take(First()).take(First())
+    let parser = first10.take(First())
+    XCTAssert(
+      try ("1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "A")
+        == XCTUnwrap(parser.parse(&input)))
+    XCTAssertEqual("", input)
+  }
+}
+
+// MARK: - Tuple Equatable Conformance
+
+func == <A, B, C, D, E, F, G>(lhs: (A, B, C, D, E, F, G), rhs: (A, B, C, D, E, F, G)) -> Bool
+where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable {
+  (lhs.0, lhs.1, lhs.2, lhs.3, lhs.4, lhs.5) == (rhs.0, rhs.1, rhs.2, rhs.3, rhs.4, rhs.5)
+    && lhs.6 == rhs.6
+}
+
+func == <A, B, C, D, E, F, G, H>(lhs: (A, B, C, D, E, F, G, H), rhs: (A, B, C, D, E, F, G, H)) -> Bool
+where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable, H: Equatable {
+  (lhs.0, lhs.1, lhs.2, lhs.3, lhs.4, lhs.5) == (rhs.0, rhs.1, rhs.2, rhs.3, rhs.4, rhs.5)
+    && (lhs.6, lhs.7) == (rhs.6, rhs.7)
+}
+
+func == <A, B, C, D, E, F, G, H, I>(lhs: (A, B, C, D, E, F, G, H, I), rhs: (A, B, C, D, E, F, G, H, I)) -> Bool
+where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable, H: Equatable, I: Equatable {
+  (lhs.0, lhs.1, lhs.2, lhs.3, lhs.4, lhs.5) == (rhs.0, rhs.1, rhs.2, rhs.3, rhs.4, rhs.5)
+    && (lhs.6, lhs.7, lhs.8) == (rhs.6, rhs.7, rhs.8)
+}
+
+func == <A, B, C, D, E, F, G, H, I, J>(lhs: (A, B, C, D, E, F, G, H, I, J), rhs: (A, B, C, D, E, F, G, H, I, J)) -> Bool
+where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable, H: Equatable, I: Equatable, J: Equatable {
+  (lhs.0, lhs.1, lhs.2, lhs.3, lhs.4, lhs.5) == (rhs.0, rhs.1, rhs.2, rhs.3, rhs.4, rhs.5)
+    && (lhs.6, lhs.7, lhs.8, lhs.9) == (rhs.6, rhs.7, rhs.8, rhs.9)
+}
+
+func == <A, B, C, D, E, F, G, H, I, J, K>(lhs: (A, B, C, D, E, F, G, H, I, J, K), rhs: (A, B, C, D, E, F, G, H, I, J, K)) -> Bool
+where A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Equatable, F: Equatable, G: Equatable, H: Equatable, I: Equatable, J: Equatable, K: Equatable {
+  (lhs.0, lhs.1, lhs.2, lhs.3, lhs.4, lhs.5) == (rhs.0, rhs.1, rhs.2, rhs.3, rhs.4, rhs.5)
+    && (lhs.6, lhs.7, lhs.8, lhs.9, lhs.10) == (rhs.6, rhs.7, rhs.8, rhs.9, lhs.10)
 }


### PR DESCRIPTION
This may not be advisable. Chaining more that 6 parsers results in a noticeable increase in compile time. At 11 parsers it can be around 20 seconds. At around 16 parsers the compiler gives up. I've written the tests in a way that reduces compile times.
