### PR TITLE
Fix float overflow on utf8 parsing

### DIFF
--- a/Sources/Parsing/Parsers/Double.swift
+++ b/Sources/Parsing/Parsers/Double.swift
@@ -128,7 +128,8 @@ extension Parsers {
       let original = input
       guard
         let s = input.parseFloat(),
-        let n = Double(String(decoding: s, as: UTF8.self))
+        let n = Double(String(decoding: s, as: UTF8.self)),
+        n <= Double.greatestFiniteMagnitude
       else {
         input = original
         return nil
@@ -163,7 +164,8 @@ extension Parsers {
       let original = input
       guard
         let s = input.parseFloat(),
-        let n = Float(String(decoding: s, as: UTF8.self))
+        let n = Float(String(decoding: s, as: UTF8.self)),
+        n <= Float.greatestFiniteMagnitude
       else {
         input = original
         return nil
@@ -199,7 +201,8 @@ extension Parsers {
         let original = input
         guard
           let s = input.parseFloat(),
-          let n = Float80(String(decoding: s, as: UTF8.self))
+          let n = Float80(String(decoding: s, as: UTF8.self)),
+          n <= Float80.greatestFiniteMagnitude
         else {
           input = original
           return nil

--- a/Tests/ParsingTests/DoubleTests.swift
+++ b/Tests/ParsingTests/DoubleTests.swift
@@ -90,10 +90,6 @@ final class DoubleTests: XCTestCase {
       XCTAssertEqual(1_234_567_890_123_456_788_999_898_750_329_779_388_416, parser.parse(&input))
       XCTAssertEqual(" Hello", String(input))
 
-      input = String(format: "1%f Hello", Float80.greatestFiniteMagnitude)[...].utf8
-      XCTAssertEqual(nil, parser.parse(&input))
-      XCTAssertEqual(String(format: "1%f Hello", Float80.greatestFiniteMagnitude), String(input))
-
       input = "-123 Hello"[...].utf8
       XCTAssertEqual(-123, parser.parse(&input))
       XCTAssertEqual(" Hello", String(input))

--- a/Tests/ParsingTests/DoubleTests.swift
+++ b/Tests/ParsingTests/DoubleTests.swift
@@ -21,6 +21,10 @@ final class DoubleTests: XCTestCase {
     XCTAssertEqual(1_234_567_890_123_456_846_996_462_118_072_609_669_120, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
 
+    input = String(format: "1%f Hello", Double.greatestFiniteMagnitude)[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual(String(format: "1%f Hello", Double.greatestFiniteMagnitude), String(input))
+
     input = "-123 Hello"[...].utf8
     XCTAssertEqual(-123, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
@@ -49,9 +53,9 @@ final class DoubleTests: XCTestCase {
     XCTAssertEqual(123.123, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
 
-    input = "1234567890123456789012345678901234567890 Hello"[...].utf8
+    input = String(format: "1%f Hello", Float.greatestFiniteMagnitude)[...].utf8
     XCTAssertEqual(nil, parser.parse(&input))
-    XCTAssertEqual("1234567890123456789012345678901234567890 Hello", String(input))
+    XCTAssertEqual(String(format: "1%f Hello", Float.greatestFiniteMagnitude), String(input))
 
     input = "-123 Hello"[...].utf8
     XCTAssertEqual(-123, parser.parse(&input))
@@ -85,6 +89,10 @@ final class DoubleTests: XCTestCase {
       input = "1234567890123456789012345678901234567890 Hello"[...].utf8
       XCTAssertEqual(1_234_567_890_123_456_788_999_898_750_329_779_388_416, parser.parse(&input))
       XCTAssertEqual(" Hello", String(input))
+
+      input = String(format: "1%f Hello", Float80.greatestFiniteMagnitude)[...].utf8
+      XCTAssertEqual(nil, parser.parse(&input))
+      XCTAssertEqual(String(format: "1%f Hello", Float80.greatestFiniteMagnitude), String(input))
 
       input = "-123 Hello"[...].utf8
       XCTAssertEqual(-123, parser.parse(&input))


### PR DESCRIPTION
I couldn't see a way to print the raw value of the Float80 to string—which prompted a feature enhancement idea: supporting scientific notation.