### PR TITLE
Add FirstMatchOf parser

### DIFF
--- a/Sources/Parsing/Parsers/FirstMatchOf.swift
+++ b/Sources/Parsing/Parsers/FirstMatchOf.swift
@@ -29,5 +29,5 @@ public struct FirstMatchOf<Input, P>: Parser
 }
 
 public extension Parsers {
-  typealias FirstMatch = Parsing.FirstMatchOf // NB: Convenience type alias for discovery
+  typealias FirstMatchOf = Parsing.FirstMatchOf // NB: Convenience type alias for discovery
 }

--- a/Sources/Parsing/Parsers/FirstMatchOf.swift
+++ b/Sources/Parsing/Parsers/FirstMatchOf.swift
@@ -1,0 +1,33 @@
+/// A parser that consumes elements of a collection one by one until and if a given parser `parser` succeeds.
+/// In case of success, the prefix is discarded and the the output of `parser` is returned.
+public struct FirstMatchOf<Input, P>: Parser
+  where
+  Input: Collection,
+  Input.SubSequence == Input,
+  P: Parser,
+  P.Input == Input
+{
+  public let parser: P
+
+  @inlinable
+  public init(_ parser: P) {
+    self.parser = parser
+  }
+
+  @inlinable
+  public func parse(_ input: inout Input) -> P.Output? {
+    let original = input
+    while !input.isEmpty {
+      if let parsed = parser.parse(&input) {
+        return parsed
+      }
+      input.removeFirst()
+    }
+    input = original
+    return nil
+  }
+}
+
+public extension Parsers {
+  typealias FirstMatch = Parsing.FirstMatchOf // NB: Convenience type alias for discovery
+}

--- a/Tests/ParsingTests/FirstMatchOfTests.swift
+++ b/Tests/ParsingTests/FirstMatchOfTests.swift
@@ -1,0 +1,18 @@
+import Parsing
+import XCTest
+
+final class FirstMatchOfTests: XCTestCase {
+  func testSuccess() {
+    var input = "42 Hello, world!"[...].utf8
+
+    XCTAssertNotNil(FirstMatchOf(StartsWith("Hello".utf8)).parse(&input))
+    XCTAssertEqual(", world!", Substring(input))
+  }
+
+  func testFailure() {
+    var input = "42 Hello, world!"[...].utf8
+
+    XCTAssertNil(FirstMatchOf(StartsWith("Bonjour".utf8)).parse(&input))
+    XCTAssertEqual("42 Hello, world!", Substring(input))
+  }
+}


### PR DESCRIPTION
A parser that consumes elements of a collection one by one until a given parser `parser` succeeds.
In case of success, the prefix is discarded and the the output of `parser` is returned.

This parser is especially useful to extract some structured data inside an arbitrary collection, like a piece of source code for example.