### PR TITLE
Fix testFloat() test

### DIFF
--- a/Tests/ParsingTests/DoubleTests.swift
+++ b/Tests/ParsingTests/DoubleTests.swift
@@ -50,9 +50,14 @@ final class DoubleTests: XCTestCase {
     XCTAssertEqual(" Hello", String(input))
 
     input = "1234567890123456789012345678901234567890 Hello"[...].utf8
-    XCTAssertEqual(nil, parser.parse(&input))
-    XCTAssertEqual("1234567890123456789012345678901234567890 Hello", String(input))
-
+    let parsed = parser.parse(&input)
+    if parsed == nil {
+      XCTAssertEqual("1234567890123456789012345678901234567890 Hello", String(input))
+    } else {
+      XCTAssertEqual(Float.infinity, parsed)
+      XCTAssertEqual(" Hello", String(input))
+    }
+   
     input = "-123 Hello"[...].utf8
     XCTAssertEqual(-123, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))


### PR DESCRIPTION
On my machine running Xcode 12.5, the test failed because it parsed `inf` instead of `nil`. I can't find in which version of Swift this behavior has changed, and I can't fence the code accordingly, but I guess this workaround still tests what matters.
I can happily close this PR if a better solution is found.