### PR TITLE
Add DelimitedBy

### DIFF
--- a/Sources/Parsing/Parsers/DelimitedBy.swift
+++ b/Sources/Parsing/Parsers/DelimitedBy.swift
@@ -1,0 +1,159 @@
+/// A parser that returns a subsequence by matching pairs of delimiters.
+/// The data must begin with `start`, and each successful match for `start` or `end` respectively open and close a matchin pair.
+/// The parser returns a subsequence of `Input` when it matches `end` with the initial `start`, closing the first level pair.
+/// In case of success, the output doesn't include the delimiters, and the last `end` portion of the input is consumed.
+/// This parser allows to parse arbitrary nested structures:
+///
+///     let delimitedParser = DelimitedBy<Substring>("(", ")")
+///
+///     var input = "(Hello,(world))!"[...]
+///     delimitedParser.parse(&input) // "Hello,(world)"
+///     input // "!"
+///
+/// If the input exceed the maximum level of nesting allowed, parsing will fail.
+/// By default, this maximum level is unlimited (`maxLevel: 0`)
+///
+/// - Warning: If the input is known to not have nested pairs of delimiters, an adhoc parser in the form of:
+///
+///     let parser = Parsers
+///     .Skip(StartsWith(start, by: areEquivalent))
+///     .take(PrefixUpTo(end, by: areEquivalent))
+///     .skip(StartsWith(end, by: areEquivalent))
+///
+/// may be more efficient. The same may also be true if the nesting level is known.
+///
+/// - Remark: If both delimiters are equivalent, this parser will be more efficient than an adhoc 1-level parser.
+public struct DelimitedBy<Input>: Parser
+  where
+  Input: Collection,
+  Input.SubSequence == Input
+{
+  public let start: Input
+  public let end: Input
+  public let areEquivalent: (Input.Element, Input.Element) -> Bool
+
+  public let maxLevel: Int
+
+  @usableFromInline
+  let startAndEndAreEquivalent: Bool
+
+  @inlinable
+  public init(
+    _ start: Input,
+    _ end: Input? = nil,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool,
+    maxLevel: Int = 0
+  ) {
+    self.start = start
+    self.startAndEndAreEquivalent = end == nil || zip(start, end!).allSatisfy(areEquivalent)
+
+    let end = end ?? start
+    self.end = end
+    self.areEquivalent = areEquivalent
+    self.maxLevel = maxLevel
+  }
+
+  @inlinable
+  @inline(__always)
+  public func parse(_ input: inout Input) -> Input? {
+    let maxLevel = self.maxLevel == 0 ? Int.max : maxLevel
+
+    guard let firstOfStart = start.first else {
+      return PrefixThrough(end, by: areEquivalent)
+        .parse(&input)
+        .map { $0.prefix($0.count - end.count) }
+    }
+    guard let firstOfEnd = end.first else {
+      return StartsWith(start, by: areEquivalent)
+        .parse(&input)
+        .map { end }
+    }
+    let startCount = start.count
+    let endCount = end.count
+    guard input.count >= startCount + endCount else { return nil }
+    guard input.starts(with: start, by: areEquivalent) else { return nil }
+
+    let original = input
+    input = input[input.index(input.startIndex, offsetBy: startCount)...]
+
+    if maxLevel == 1 {
+      while let index = input.firstIndex(where: { areEquivalent(firstOfEnd, $0) }) {
+        if input[index...].starts(with: end, by: areEquivalent) {
+          var candidate = original[original.index(original.startIndex, offsetBy: startCount)..<index]
+          let originalCandidate = candidate
+          while let firstIndex = candidate.firstIndex(where: { areEquivalent(firstOfStart, $0) }) {
+            if candidate[firstIndex...].starts(with: start, by: areEquivalent) {
+              input = original
+              return nil
+            }
+            candidate = candidate[firstIndex...]
+          }
+          input = input[input.index(index, offsetBy: endCount)...]
+          return originalCandidate
+        }
+      }
+    } else {
+      var level: Int = 1
+      while let index = input.firstIndex(where: {
+        areEquivalent(firstOfStart, $0)
+          || (!startAndEndAreEquivalent && areEquivalent(firstOfEnd, $0))
+      }) {
+        input = input[index...]
+        if startAndEndAreEquivalent {
+          if input[index...].starts(with: start, by: areEquivalent) {
+            input = input[input.index(index, offsetBy: startCount)...]
+            return original[original.index(original.startIndex, offsetBy: startCount)..<index]
+          }
+        } else {
+          if input[index...].starts(with: end, by: areEquivalent) {
+            guard level == 1 else {
+              level -= 1
+              input.removeFirst(endCount)
+              continue
+            }
+            input = input[input.index(index, offsetBy: endCount)...]
+            return original[original.index(original.startIndex, offsetBy: startCount)..<index]
+          }
+
+          if input[index...].starts(with: start, by: areEquivalent) {
+            guard level < maxLevel else {
+              input = original
+              return nil
+            }
+            level += 1
+            input.removeFirst(startCount)
+            continue
+          }
+        }
+      }
+    }
+
+    input = original
+    return nil
+  }
+}
+
+public extension DelimitedBy where Input.Element: Equatable {
+  @inlinable
+  init(_ start: Input, _ end: Input? = nil, maxLevel: Int = 0) {
+    self.init(start, end, by: ==, maxLevel: maxLevel)
+  }
+}
+
+public extension Parsers {
+  typealias Delimited = Parsing.DelimitedBy // NB: Convenience type alias for discovery
+}
+
+public extension DelimitedBy where Input == Substring {
+  @inlinable
+  init(_ start: String, _ end: String? = nil, maxLevel: Int = 0) {
+    self.init(start[...], end?[...], maxLevel: maxLevel)
+  }
+}
+
+public extension DelimitedBy where Input == Substring.UTF8View {
+  @inlinable
+  init(_ start: String.UTF8View, _ end: String.UTF8View? = nil, maxLevel: Int = 0) {
+    self.init(String(start)[...].utf8, end.map { String($0)[...].utf8 }, maxLevel: maxLevel)
+  }
+}

--- a/Sources/Parsing/Parsers/DelimitedBy.swift
+++ b/Sources/Parsing/Parsers/DelimitedBy.swift
@@ -56,7 +56,7 @@ public struct DelimitedBy<Input>: Parser
   @inlinable
   @inline(__always)
   public func parse(_ input: inout Input) -> Input? {
-    let maxLevel = self.maxLevel == 0 ? Int.max : maxLevel
+    let maxLevel = self.maxLevel == 0 ? Int.max : self.maxLevel
 
     guard let firstOfStart = start.first else {
       return PrefixThrough(end, by: areEquivalent)

--- a/Sources/swift-parsing-benchmark/DelimitedByBenchmarks.swift
+++ b/Sources/swift-parsing-benchmark/DelimitedByBenchmarks.swift
@@ -1,0 +1,74 @@
+import Benchmark
+import Foundation
+import Parsing
+
+//  name                                       time          std        iterations
+//  ------------------------------------------------------------------------------
+//  DelimitedBy.1-Level-DelimitedBy            166841.000 ns ±  17.58 %       7148
+//  DelimitedBy.1-Level-DelimitedBy-MaxLevel-1  79969.000 ns ±  18.54 %      16657
+//  DelimitedBy.1-Level-Composite               30869.000 ns ±  22.09 %      41878
+//  DelimitedBy.SameDelimiter-DelimitedBy       18448.000 ns ±  22.99 %      70959
+//  DelimitedBy.SameDelimiter-Composite         30881.000 ns ±  21.26 %      43653
+//  DelimitedBy.Nested-DelimitedBy             167025.000 ns ±  15.00 %       7884
+//  DelimitedBy.Nested-Ad-Hoc-Composite         40625.000 ns ±  17.86 %      31736
+
+let delimitedBySuite = BenchmarkSuite(name: "DelimitedBy") { suite in
+  let expectedNested = String(repeating: ".", count: 10_000) + "(Hello), world!"
+  let strNested = "(" + expectedNested + ")"
+  let expectedNestedCount = expectedNested.count
+
+  let expected = String(repeating: ".", count: 10_000) + "Hello, world!"
+  let str = "(" + expected + ")"
+  let strSame = "|" + expected + "|"
+  let expectedCount = expected.count
+
+  suite.benchmark("1-Level-DelimitedBy") {
+    var v = str[...].utf8
+    precondition(DelimitedBy("(".utf8, ")".utf8).parse(&v)!.count == expectedCount)
+  }
+    
+  suite.benchmark("1-Level-DelimitedBy-MaxLevel-1") {
+    var v = str[...].utf8
+    precondition(DelimitedBy("(".utf8, ")".utf8, maxLevel: 1).parse(&v)!.count == expectedCount)
+  }
+    
+  suite.benchmark("1-Level-Composite") {
+    var v = str[...].utf8
+    let parser = Parsers
+      .Skip(StartsWith("(".utf8))
+      .take(PrefixUpTo(")".utf8))
+      .skip(StartsWith(")".utf8))
+    precondition(parser.parse(&v)!.count == expectedCount)
+  }
+  
+  suite.benchmark("SameDelimiter-DelimitedBy") {
+    var v = strSame[...].utf8
+    precondition(DelimitedBy("|".utf8).parse(&v)!.count == expectedCount)
+  }
+  
+  suite.benchmark("SameDelimiter-Composite") {
+    var v = strSame[...].utf8
+    let parser = Parsers
+      .Skip(StartsWith("|".utf8))
+      .take(PrefixUpTo("|".utf8))
+      .skip(StartsWith("|".utf8))
+    precondition(parser.parse(&v)!.count == expectedCount)
+  }
+  
+  suite.benchmark("Nested-DelimitedBy") {
+    var v = strNested[...].utf8
+    precondition(DelimitedBy("(".utf8, ")".utf8).parse(&v)!.count == expectedNestedCount)
+  }
+  
+  suite.benchmark("Nested-Ad-Hoc-Composite") {
+    var v = strNested[...].utf8
+    let parser = Parsers
+      .Skip(StartsWith("(".utf8))
+      .take(PrefixUpTo("(".utf8))
+      .take(PrefixThrough(")".utf8))
+      .take(PrefixUpTo(")".utf8))
+      .skip(StartsWith(")".utf8))
+      .map { [$0, $1, $2].joined() }
+    precondition(parser.parse(&v)!.count == expectedNestedCount)
+  }
+}

--- a/Sources/swift-parsing-benchmark/main.swift
+++ b/Sources/swift-parsing-benchmark/main.swift
@@ -10,6 +10,7 @@ Benchmark.main(
     colorSuite,
     csvSuite,
     dateSuite,
+    delimitedBySuite,
     httpSuite,
     jsonSuite,
     numericsSuite,

--- a/Tests/ParsingTests/DelimitedByTests.swift
+++ b/Tests/ParsingTests/DelimitedByTests.swift
@@ -1,0 +1,70 @@
+import Parsing
+import XCTest
+
+final class DelimitedByTests: XCTestCase {
+  func testSuccess() {
+    var input = "(Hello,world), 42!"[...]
+    XCTAssertEqual("Hello,world", DelimitedBy("(", ")").parse(&input))
+    XCTAssertEqual(", 42!", input)
+  }
+  
+  func testSuccessIsNested() {
+    var input = "(Hel(l(o)),(world)), 42!"[...]
+    XCTAssertEqual("Hel(l(o)),(world)", DelimitedBy("(", ")").parse(&input))
+    XCTAssertEqual(", 42!", input)
+  }
+  
+  func testSuccessSameDelimiters() {
+    var input = "-Hello,world-, 42!"[...]
+    XCTAssertEqual("Hello,world", DelimitedBy("-").parse(&input))
+    XCTAssertEqual(", 42!", input)
+  }
+  
+  func testSuccessSameDelimitersNested() {
+    var input = "-Hello,-world--, 42!"[...]
+    XCTAssertEqual("Hello,", DelimitedBy("-").parse(&input))
+    XCTAssertEqual("world--, 42!", input)
+  }
+  
+  func testSuccessStartIsEmpty() {
+    var input = "(Hello,(world)), 42!"[...]
+    XCTAssertEqual("(Hello,(world", DelimitedBy("", ")").parse(&input))
+    XCTAssertEqual("), 42!", input)
+  }
+  
+  func testSuccessEndIsEmpty() {
+    var input = "(Hello,(world)), 42!"[...]
+    XCTAssertEqual("", DelimitedBy("(", "").parse(&input))
+    XCTAssertEqual("Hello,(world)), 42!", input)
+  }
+  
+  func testSuccessStartAndEndAreEmpty() {
+    var input = "(Hello,(world)), 42!"[...]
+    XCTAssertEqual("", DelimitedBy("", "").parse(&input))
+    XCTAssertEqual("(Hello,(world)), 42!", input)
+  }
+  
+  func testSuccessIsEmptyStartAndEndAreEmpty() {
+    var input = ""[...]
+    XCTAssertEqual("", DelimitedBy("").parse(&input))
+    XCTAssertEqual("", input)
+  }
+  
+  func testFailureExceedingMaxLevel() {
+    var input = "(Hello,(world)), 42!"[...]
+    XCTAssertEqual(nil, DelimitedBy("(", ")", maxLevel: 1).parse(&input))
+    XCTAssertEqual("(Hello,(world)), 42!", input)
+  }
+  
+  func testFailureIsEmpty() {
+    var input = ""[...]
+    XCTAssertEqual(nil, DelimitedBy("(", ")").parse(&input))
+    XCTAssertEqual("", input)
+  }
+
+  func testUTF8() {
+    var input = "(Hello,(world)), 42!"[...].utf8
+    XCTAssertEqual("Hello,(world)", DelimitedBy("(".utf8, ")".utf8).parse(&input).map(Substring.init))
+    XCTAssertEqual(", 42!", Substring(input))
+  }
+}


### PR DESCRIPTION
This parser matches content enclosed between pairs of delimiters. I feel the use-cases are general enough to justify a PR.
It is helpful when nesting of delimiters is unknown, as it will only match the top level pair. A maximum level of nesting can also be specified.
```
name                                       time          std        iterations
------------------------------------------------------------------------------
DelimitedBy.1-Level-DelimitedBy            166841.000 ns ±  17.58 %       7148
DelimitedBy.1-Level-DelimitedBy-MaxLevel-1  79969.000 ns ±  18.54 %      16657
DelimitedBy.1-Level-Composite               30869.000 ns ±  22.09 %      41878

DelimitedBy.SameDelimiter-DelimitedBy       18448.000 ns ±  22.99 %      70959
DelimitedBy.SameDelimiter-Composite         30881.000 ns ±  21.26 %      43653

DelimitedBy.Nested-DelimitedBy             167025.000 ns ±  15.00 %       7884
DelimitedBy.Nested-Ad-Hoc-Composite         40625.000 ns ±  17.86 %      31736
```
A benchmark suite is included. A 1-level `DelimitedBy` parser performs 2x slower than an adhoc parser, but with the guarantee that the result is enclosed in a matching pair (and if `maxLevel=1`, free of delimiters). If the level of nesting is not specified, the `DelimitedBy` parser performs 6x slower, with the same guarantee.

If the delimiters are the same, `DelimitedBy` performs 30% faster than an adhoc solution.

In case of nesting, `DelimitedBy` always takes the same time, but adhoc solutions will be more complex and slower as the supported level of nesting rises. It performs for example 4x slower than an adhoc parser made for matching with one inner pair exactly "`(xx(xx)x)`". I didn't implement branches for `(x(xx)x(xx)(x)...)` nor `(xxx)`. For deeper nesting, the combinatorics should immediately plays in favor of `DelimitedBy`, if not performance-wise, maintenance-wise.

Please let me know if you see room for improvement.