### PR TITLE
Int parser fix on just "-" or "+"

### DIFF
--- a/Sources/Parsing/Parsers/Int.swift
+++ b/Sources/Parsing/Parsers/Int.swift
@@ -121,9 +121,8 @@ extension Parsers {
         guard !overflow else { return nil }
         length += 1
       }
-      guard length > 0
+      guard length > (parsedSign ? 1 : 0)
       else { return nil }
-      if parsedSign && length == 1 { return nil }
       input.removeFirst(length)
       return output
     }

--- a/Sources/Parsing/Parsers/Int.swift
+++ b/Sources/Parsing/Parsers/Int.swift
@@ -92,17 +92,21 @@ extension Parsers {
       var iterator = input.makeIterator()
       guard let first = iterator.next() else { return nil }
       let isPositive: Bool
+      let parsedSign: Bool
       var overflow = false
       var output: Output
       switch (self.isSigned, first) {
       case (true, .init(ascii: "-")):
+        parsedSign = true
         isPositive = false
         output = 0
       case (true, .init(ascii: "+")):
+        parsedSign = true
         isPositive = true
         output = 0
       case let (_, n):
         guard let n = digit(for: n) else { return nil }
+        parsedSign = false
         isPositive = true
         output = n
       }
@@ -119,6 +123,7 @@ extension Parsers {
       }
       guard length > 0
       else { return nil }
+      if parsedSign && length == 1 { return nil }
       input.removeFirst(length)
       return output
     }

--- a/Tests/ParsingTests/DoubleTests.swift
+++ b/Tests/ParsingTests/DoubleTests.swift
@@ -32,6 +32,14 @@ final class DoubleTests: XCTestCase {
     input = "Hello"[...].utf8
     XCTAssertEqual(nil, parser.parse(&input))
     XCTAssertEqual("Hello", String(input))
+
+    input = "- Hello"[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual("- Hello", String(input))
+
+    input = "+ Hello"[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual("+ Hello", String(input))
   }
 
   func testFloat() {
@@ -69,6 +77,14 @@ final class DoubleTests: XCTestCase {
     input = "Hello"[...].utf8
     XCTAssertEqual(nil, parser.parse(&input))
     XCTAssertEqual("Hello", String(input))
+
+    input = "- Hello"[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual("- Hello", String(input))
+
+    input = "+ Hello"[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual("+ Hello", String(input))
   }
 
   #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
@@ -102,6 +118,14 @@ final class DoubleTests: XCTestCase {
       input = "Hello"[...].utf8
       XCTAssertEqual(nil, parser.parse(&input))
       XCTAssertEqual("Hello", String(input))
+
+      input = "- Hello"[...].utf8
+      XCTAssertEqual(nil, parser.parse(&input))
+      XCTAssertEqual("- Hello", String(input))
+
+      input = "+ Hello"[...].utf8
+      XCTAssertEqual(nil, parser.parse(&input))
+      XCTAssertEqual("+ Hello", String(input))
     }
   #endif
 }

--- a/Tests/ParsingTests/IntTests.swift
+++ b/Tests/ParsingTests/IntTests.swift
@@ -28,6 +28,14 @@ final class IntTests: XCTestCase {
     input = "Hello"[...].utf8
     XCTAssertEqual(nil, parser.parse(&input))
     XCTAssertEqual("Hello", String(input))
+
+    input = "- Hello"[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual("- Hello", String(input))
+
+    input = "+ Hello"[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual("+ Hello", String(input))
   }
 
   func testOverflow() {


### PR DESCRIPTION
Fix for an issue discussed in https://github.com/pointfreeco/swift-parsing/discussions/36

Int parser should fail if a sign (-/+) is not followed by a digit.

Tests for Double and Float parsers are also added to prevent a possible introduction of this issue there in the future.

Note: I wanted to use `guard` for a check but both following examples didn't feel as straightforward as `if`:
```swift
guard !(parsedSign && length == 1) 
else { return nil }
```
```swift
guard !parsedSign || length != 1
else { return nil }
``` 