### PR TITLE
Remove benchmark product

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "Benchmark",
+        "package": "swift-benchmark",
         "repositoryURL": "https://github.com/google/swift-benchmark",
         "state": {
           "branch": null,

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,6 @@ let package = Package(
       name: "Parsing",
       targets: ["Parsing"]
     ),
-    .executable(
-      name: "swift-parsing-benchmark",
-      targets: ["swift-parsing-benchmark"]
-    ),
   ],
   dependencies: [
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0")


### PR DESCRIPTION
Exposing the benchmark executable as a product makes its dependencies show up when depending on the package downstream. This means you'll see swift-argument-parser and swift-benchmark in your project when you depend on swift-parsing. By removing the product, these details should no longer be exposed downstream, and the benchmark still shows up just fine as an executable when working directly on swift-parsing.