### PR TITLE
Harness SE-0299 to improve parser discoverability and ergonomics

### DIFF
--- a/Sources/Parsing/Parsers/Always.swift
+++ b/Sources/Parsing/Parsers/Always.swift
@@ -1,3 +1,4 @@
+import Foundation
 /// A parser that always succeeds by returning the provided value, but does not consume any of its
 /// input.
 ///
@@ -9,17 +10,17 @@
 /// ```
 public struct Always<Input, Output>: Parser {
   public let output: Output
-
+  
   @inlinable
   public init(_ output: Output) {
     self.output = output
   }
-
+  
   @inlinable
   public func parse(_ input: inout Input) -> Output? {
     self.output
   }
-
+  
   @inlinable
   public func map<NewOutput>(
     _ transform: @escaping (Output) -> NewOutput
@@ -30,4 +31,11 @@ public struct Always<Input, Output>: Parser {
 
 extension Parsers {
   public typealias Always = Parsing.Always  // NB: Convenience type alias for discovery
+}
+
+extension Parser {
+  @inlinable
+  public static func always<Input, Output>(_ output: Output) -> Self where Self == Always<Input, Output> {
+    return .init(output)
+  }
 }

--- a/Sources/Parsing/Parsers/Always.swift
+++ b/Sources/Parsing/Parsers/Always.swift
@@ -1,4 +1,3 @@
-import Foundation
 /// A parser that always succeeds by returning the provided value, but does not consume any of its
 /// input.
 ///

--- a/Sources/Parsing/Parsers/End.swift
+++ b/Sources/Parsing/Parsers/End.swift
@@ -7,7 +7,7 @@
 public struct End<Input>: Parser where Input: Collection {
   @inlinable
   public init() {}
-
+  
   @inlinable
   public func parse(_ input: inout Input) -> Void? {
     guard input.isEmpty else { return nil }
@@ -17,4 +17,11 @@ public struct End<Input>: Parser where Input: Collection {
 
 extension Parsers {
   public typealias End = Parsing.End  // NB: Convenience type alias for discovery
+}
+
+extension Parser {
+  @inlinable
+  public static func end<Input>() -> Self where Self == End<Input>, Input: Collection {
+    return .init()
+  }
 }

--- a/Sources/Parsing/Parsers/Fail.swift
+++ b/Sources/Parsing/Parsers/Fail.swift
@@ -6,7 +6,7 @@
 public struct Fail<Input, Output>: Parser {
   @inlinable
   public init() {}
-
+  
   @inlinable
   public func parse(_ input: inout Input) -> Output? {
     nil
@@ -15,4 +15,11 @@ public struct Fail<Input, Output>: Parser {
 
 extension Parsers {
   public typealias Fail = Parsing.Fail  // NB: Convenience type alias for discovery
+}
+
+extension Parser {
+  @inlinable
+  public static func fail<Input, Output>() -> Self where Self == Fail<Input, Output> {
+    return .init()
+  }
 }

--- a/Sources/Parsing/Parsers/First.swift
+++ b/Sources/Parsing/Parsers/First.swift
@@ -33,3 +33,10 @@ where
 extension Parsers {
   public typealias First = Parsing.First  // NB: Convenience type alias for discovery
 }
+
+extension Parser {
+  @inlinable
+  public static func first<Input>() -> Self where Self == First<Input> {
+    return .init()
+  }
+}

--- a/Sources/Parsing/Parsers/FirstWhere.swift
+++ b/Sources/Parsing/Parsers/FirstWhere.swift
@@ -21,3 +21,11 @@ where
 extension Parsers {
   public typealias FirstWhere = Parsing.FirstWhere  // NB: Convenience type alias for discovery
 }
+
+extension Parser {
+  @inlinable
+  public static func firstWhere<Input>(_ predicate: @escaping (Input.Element) -> Bool)
+  -> Self where Self == FirstWhere<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init(predicate)
+  }
+}

--- a/Sources/Parsing/Parsers/Newline.swift
+++ b/Sources/Parsing/Parsers/Newline.swift
@@ -26,3 +26,11 @@ where
 extension Parsers {
   public typealias Newline = Parsing.Newline  // NB: Convenience type alias for discovery
 }
+
+extension Parser {
+  @inlinable
+  public static func newLine<Input>()
+  -> Self where Self == Newline<Input>, Input: Collection, Input.SubSequence == Input, Input.Element == UTF8.CodeUnit {
+    return .init()
+  }
+}

--- a/Sources/Parsing/Parsers/Prefix.swift
+++ b/Sources/Parsing/Parsers/Prefix.swift
@@ -167,3 +167,46 @@ where
 extension Parsers {
   public typealias Prefix = Parsing.Prefix  // NB: Convenience type alias for discovery
 }
+
+extension Parser {
+  @inlinable
+  public static func prefix<Input>(
+    minLength: Int = 0,
+    maxLength: Int? = nil,
+    while predicate: @escaping (Input.Element) -> Bool
+  ) -> Self where Self == Prefix<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init(minLength: minLength, maxLength: maxLength, while: predicate)
+  }
+  
+  @inlinable
+  public static func prefix<Input>(
+    _ length: ClosedRange<Int>,
+    while predicate: ((Input.Element) -> Bool)? = nil
+  ) -> Self where Self == Prefix<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init(length, while: predicate)
+  }
+  
+  @inlinable
+  public static func prefix<Input>(
+    _ length: Int,
+    while predicate: ((Input.Element) -> Bool)? = nil
+  ) -> Self where Self == Prefix<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init(length, while: predicate)
+  }
+  
+  @inlinable
+  public static func prefix<Input>(
+    _ length: PartialRangeFrom<Int>,
+    while predicate: ((Input.Element) -> Bool)? = nil
+  ) -> Self where Self == Prefix<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init(length, while: predicate)
+  }
+  
+  @inlinable
+  public static func prefix<Input>(
+    _ length: PartialRangeThrough<Int>,
+    while predicate: ((Input.Element) -> Bool)? = nil
+  ) -> Self where Self == Prefix<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init(length, while: predicate)
+  }
+}

--- a/Sources/Parsing/Parsers/PrefixThrough.swift
+++ b/Sources/Parsing/Parsers/PrefixThrough.swift
@@ -74,3 +74,31 @@ extension PrefixThrough where Input == Substring.UTF8View {
     self.init(String(possibleMatch)[...].utf8)
   }
 }
+
+extension Parser {
+  @inlinable
+  public static func prefixThrough<Input>(
+    _ possibleMatch: Input,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+  ) -> Self where Self == PrefixThrough<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init(possibleMatch, by: areEquivalent)
+  }
+  
+  @inlinable
+  public static func prefixThrough<Input>(_ possibleMatch: Input)
+  -> Self where Self == PrefixThrough<Input>, Input: Collection, Input.SubSequence == Input, Input.Element: Equatable {
+    return .init(possibleMatch, by: ==)
+  }
+  
+  @inlinable
+  public static func prefixThrough(_ possibleMatch: String)
+  -> Self where Self == PrefixThrough<Substring> {
+    return .init(possibleMatch[...])
+  }
+  
+  @inlinable
+  public static func prefixThrough(_ possibleMatch: String.UTF8View)
+  -> Self where Self == PrefixThrough<Substring.UTF8View> {
+    return .init(String(possibleMatch)[...].utf8)
+  }
+}

--- a/Sources/Parsing/Parsers/PrefixUpTo.swift
+++ b/Sources/Parsing/Parsers/PrefixUpTo.swift
@@ -72,3 +72,32 @@ extension PrefixUpTo where Input == Substring.UTF8View {
     self.init(String(possibleMatch)[...].utf8)
   }
 }
+
+extension Parser {
+  @inlinable
+  public static func prefixUpTo<Input>(
+    _ possibleMatch: Input,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+  ) -> Self where Self == PrefixUpTo<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init(possibleMatch, by: areEquivalent)
+  }
+  
+  @inlinable
+  public static func prefixUpTo<Input>(_ possibleMatch: Input)
+  -> Self where Self == PrefixUpTo<Input>, Input: Collection, Input.SubSequence == Input, Input.Element: Equatable {
+    return .init(possibleMatch, by: ==)
+  }
+  
+  @inlinable
+  public static func prefixUpTo(_ possibleMatch: String)
+  -> Self where Self == PrefixUpTo<Substring> {
+    return .init(possibleMatch[...])
+  }
+  
+  @inlinable
+  public static func prefixUpTo(_ possibleMatch: String.UTF8View)
+  -> Self where Self == PrefixUpTo<Substring.UTF8View> {
+    return .init(String(possibleMatch)[...].utf8)
+  }
+}
+

--- a/Sources/Parsing/Parsers/Rest.swift
+++ b/Sources/Parsing/Parsers/Rest.swift
@@ -18,3 +18,10 @@ where
 extension Parsers {
   public typealias Rest = Parsing.Rest  // NB: Convenience type alias for discovery
 }
+
+extension Parser {
+  @inlinable
+  public static func rest<Input>() -> Self where Self == Rest<Input>, Input: Collection, Input.SubSequence == Input {
+    return .init()
+  }
+}

--- a/Sources/Parsing/Parsers/StartsWith.swift
+++ b/Sources/Parsing/Parsers/StartsWith.swift
@@ -78,3 +78,27 @@ extension Parsers.StartsWith where Input.Element: Equatable {
 extension Parsers {
   public typealias StartsWith = Parsing.StartsWith  // NB: Convenience type alias for discovery
 }
+
+extension Parser {
+  @inlinable
+  public static func startsWith<Input, PossiblePrefix>(
+    _ possiblePrefix: PossiblePrefix,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+  ) -> Self where Self == StartsWith<Input>,
+       Input: Collection, Input.SubSequence == Input,
+       PossiblePrefix: Collection, PossiblePrefix.Element == Input.Element
+  {
+    return .init(possiblePrefix, by: areEquivalent)
+  }
+  
+  @inlinable
+  public static func startsWith<Input, PossiblePrefix>(
+    _ possiblePrefix: PossiblePrefix,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+  ) -> Self where Self == StartsWith<Input>,
+       Input: Collection, Input.SubSequence == Input, Input.Element: Equatable,
+       PossiblePrefix: Collection, PossiblePrefix.Element == Input.Element
+  {
+    return .init(possiblePrefix, by: ==)
+  }
+}

--- a/Sources/Parsing/Parsers/Whitespace.swift
+++ b/Sources/Parsing/Parsers/Whitespace.swift
@@ -24,3 +24,11 @@ where
 extension Parsers {
   public typealias Whitespace = Parsing.Whitespace  // NB: Convenience type alias for discovery
 }
+
+extension Parser {
+  @inlinable
+  public static func whiteSpace<Input>()
+  -> Self where Self == Whitespace<Input>, Input: Collection, Input.SubSequence == Input, Input.Element == UTF8.CodeUnit {
+    return .init()
+  }
+}


### PR DESCRIPTION
Hello there! I'd like to propose an important addition to the library.

 [SE-0299](https://github.com/apple/swift-evolution/blob/main/proposals/0299-extend-generic-static-member-lookup.md), called "Extending Static Member Lookup in Generic Contexts", offers a way to use static member dot-syntax in generic contexts, like so:
```swift
extension View {
  func buttonStyle<S>(_ style: S) -> some View where S: PrimitiveButtonStyle { /*...*/ }
}

struct BorderedButtonStyle: PrimitiveButtonStyle { /*...*/ }

// before:
Button(action: { viewStore.send(.increment) }) { /*...*/ }
  .buttonStyle(BorderedButtonStyle())

// after:
extension PrimitiveButtonStyle where Self == BorderedButtonStyle {
  static var bordered: Self { .init() }
}

Button(action: { viewStore.send(.increment) }) { /*...*/ }
  .buttonStyle(.bordered)
```

This feature was created due to the poor discoverability of these `...Style` structs. Now the code is much more readable, and Xcode can offer autocomplete suggestions.

This library unfortunately has the same problem – there are a lot of different parsers available, but their discoverability is very poor. There have been discussions about this already, with [one for example](https://github.com/pointfreeco/swift-parsing/discussions/4) proposing putting more parsers in the Parser namespace. 

Using this new language feature however, we can vastly improve discoverability and ergonomics without moving around any of the structs or even modifying them – this change is completely additive.

Here's an example of what this would look like:
```swift
let user = Int.parser()
  .skip(.startsWith(","))
  .take(.prefix { $0 != "," })
  .map { User(id: $0, name: String($1)) }
```

And here's an example of what adding one of the static members looks like. It looks a little different than the SwiftUI example because there are generics involved:
```swift
extension Parser {
  @inlinable
  public static func firstWhere<Input>(_ predicate: @escaping (Input.Element) -> Bool)
  -> Self where Self == FirstWhere<Input>, Input: Collection, Input.SubSequence == Input {
    return .init(predicate)
  }
}
```

I've implemented these static function extensions for:
- Always
- End
- Fail
- First
- FirstWhere
- Newline
- Prefix
- PrefixThrough
- PrefixUpTo
- Rest
- StartsWith
- Whitespace

These are parsers which make sense to use as a base parser (unlike Map, Skip, etc.) and they are also parsers which don’t wrap other parsers (such as Many, Lazy, etc.). I feel like these “higher-order parsers” should be created using their initialisers, similar to Publishers.MergeMany or Publishers.Zip2 - but I’d be happy to make static function extensions for those too if need be.

I feel like this addition would solve many of the problems people currently feel with discoverability and ergonomics while still keeping a familiar and idiomatic API.
