### PR TITLE
Deprecate `FirstWhere`

### DIFF
--- a/Sources/Parsing/Parsers/FirstWhere.swift
+++ b/Sources/Parsing/Parsers/FirstWhere.swift
@@ -19,6 +19,7 @@ where
   }
 }
 
+@availability(*, deprecated, message: "Use 'First().filter(predicate) instead")
 extension Parsers {
   public typealias FirstWhere = Parsing.FirstWhere  // NB: Convenience type alias for discovery
 }

--- a/Sources/Parsing/Parsers/FirstWhere.swift
+++ b/Sources/Parsing/Parsers/FirstWhere.swift
@@ -1,3 +1,4 @@
+@availability(*, deprecated, message: "Use 'First().filter(predicate) instead")
 public struct FirstWhere<Input>: Parser
 where
   Input: Collection,

--- a/Sources/Parsing/Parsers/FirstWhere.swift
+++ b/Sources/Parsing/Parsers/FirstWhere.swift
@@ -1,4 +1,4 @@
-@availability(*, deprecated, message: "Use 'First().filter(predicate) instead")
+@available(*, deprecated, message: "Use 'First().filter(predicate) instead")
 public struct FirstWhere<Input>: Parser
 where
   Input: Collection,
@@ -19,7 +19,7 @@ where
   }
 }
 
-@availability(*, deprecated, message: "Use 'First().filter(predicate) instead")
+@available(*, deprecated, message: "Use 'First().filter(predicate) instead")
 extension Parsers {
   public typealias FirstWhere = Parsing.FirstWhere  // NB: Convenience type alias for discovery
 }


### PR DESCRIPTION
After seeing #48 come in it became clear that this parser is maybe not worth including in the library. First, its behavior is different than `Collection.first(where:)`, which "consumes" the collection till the first match, but our parser merely filters based on the first match. And so really, we could be explicit using existing operators:

- `First().filter(predicate)` for the existing behavior
- `Skip(Prefix(while: { !predicate($0) })).take(First())` for behavior similar to `Collection.first(where:)`