### PR TITLE
Prefix should match when maxLength < match.count

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "swift-benchmark",
+        "package": "Benchmark",
         "repositoryURL": "https://github.com/google/swift-benchmark",
         "state": {
           "branch": null,

--- a/Sources/Parsing/Parsers/Prefix.swift
+++ b/Sources/Parsing/Parsers/Prefix.swift
@@ -148,19 +148,12 @@ where
 
   @inlinable
   public func parse(_ input: inout Input) -> Input? {
-    if let predicate = self.predicate {
-      let prefix = input.prefix(while: predicate)
-      let count = maxLength.map { min($0, prefix.count) } ?? prefix.count
-      guard count >= self.minLength else { return nil }
-      input.removeFirst(count)
-      return prefix.prefix(count)
-    } else {
-      let prefix = self.maxLength.map(input.prefix) ?? input
-      let count = prefix.count
-      guard count >= self.minLength else { return nil }
-      input.removeFirst(count)
-      return prefix
-    }
+    var prefix = maxLength.map(input.prefix) ?? input
+    prefix = predicate.map { prefix.prefix(while: $0) } ?? input
+    let count = prefix.count
+    guard count >= self.minLength else { return nil }
+    input.removeFirst(count)
+    return prefix
   }
 }
 

--- a/Sources/Parsing/Parsers/Prefix.swift
+++ b/Sources/Parsing/Parsers/Prefix.swift
@@ -149,7 +149,7 @@ where
   @inlinable
   public func parse(_ input: inout Input) -> Input? {
     var prefix = maxLength.map(input.prefix) ?? input
-    prefix = predicate.map { prefix.prefix(while: $0) } ?? input
+    prefix = predicate.map { prefix.prefix(while: $0) } ?? prefix
     let count = prefix.count
     guard count >= self.minLength else { return nil }
     input.removeFirst(count)

--- a/Sources/Parsing/Parsers/Prefix.swift
+++ b/Sources/Parsing/Parsers/Prefix.swift
@@ -150,10 +150,10 @@ where
   public func parse(_ input: inout Input) -> Input? {
     if let predicate = self.predicate {
       let prefix = input.prefix(while: predicate)
-      let count = prefix.count
-      guard count >= self.minLength, self.maxLength.map({ count <= $0 }) ?? true else { return nil }
+      let count = maxLength.map { min($0, prefix.count) } ?? prefix.count
+      guard count >= self.minLength else { return nil }
       input.removeFirst(count)
-      return prefix
+      return prefix.prefix(count)
     } else {
       let prefix = self.maxLength.map(input.prefix) ?? input
       let count = prefix.count

--- a/Tests/ParsingTests/PrefixTests.swift
+++ b/Tests/ParsingTests/PrefixTests.swift
@@ -61,4 +61,10 @@ final class PrefixTests: XCTestCase {
     XCTAssertEqual("42", Prefix(...10, while: { $0.isNumber }).parse(&input))
     XCTAssertEqual(" Hello, world!", input)
   }
+
+  func testPrefixLengthFromWhileSuccess() {
+    var input = "42 Hello, world!"[...]
+    XCTAssertEqual("4", Prefix(1, while: { $0.isNumber }).parse(&input))
+    XCTAssertEqual("2 Hello, world!", input)
+  }
 }


### PR DESCRIPTION
Another thing noticed by #48. I think our existing behavior wasn't quite right.