### PR TITLE
Fix Windows support, expand GHA platform coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,6 @@ jobs:
           Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
 
       - name: Build
-        run: swift build
+        run: swift build --target Parsing
       - name: Run tests
         run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   macos_tests:
-    runs-on: macOS-latest
+    runs-on: macos-11
     strategy:
       matrix:
         xcode:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 jobs:
-  tests:
+  macos_tests:
     runs-on: macOS-latest
     strategy:
       matrix:
@@ -28,7 +28,7 @@ jobs:
       - name: Run ${{ matrix.command }}
         run: make ${{ matrix.command }}
 
-  windows_build:
+  windows_tests:
     runs-on: windows-2019
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 jobs:
   macos_tests:
@@ -27,6 +27,20 @@ jobs:
         run: system_profiler SPHardwareDataType
       - name: Run ${{ matrix.command }}
         run: make ${{ matrix.command }}
+
+  ubuntu_tests:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test
 
   windows_tests:
     runs-on: windows-2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - 11.7
-          - 12.5
+          - 11.7 # Latest Xcode with Swift 5.2
+          - 12.4 # Swift 5.3
+          - 12.5 # Swift 5.4
+          - 13.0 # Swift 5.5
         command:
           - test
           - benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - '*'
 
 jobs:
   macos_tests:
@@ -15,7 +15,7 @@ jobs:
       matrix:
         xcode:
           - 11.7
-          - 12.3
+          - 12.5
         command:
           - test
           - benchmarks
@@ -47,27 +47,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: seanmiddleditch/gha-setup-vsdevenv@v3
-
-      - name: Install Swift 5.4
-        run: |
-          Install-Binary -Url "https://swift.org/builds/swift-5.4.2-release/windows10/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-      - name: Set Environment Variables
-        run: |
-          echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "DEVELOPER_DIR=C:\Library\Developer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: Adjust Paths
-        run: |
-          echo "C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Install Supporting Files
-        run: |
-          Copy-Item "$env:SDKROOT\usr\share\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
-          Copy-Item "$env:SDKROOT\usr\share\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
-          Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
-          Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
-
-      - name: Build
-        run: swift build --target Parsing
-      - name: Run tests
-        run: swift test
+      - uses: MaxDesiatov/swift-windows-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - 11.7 # Latest Xcode with Swift 5.2
-          - 12.4 # Swift 5.3
-          - 12.5 # Swift 5.4
-          - 13.0 # Swift 5.5
+          - "11.7" # Latest Xcode with Swift 5.2
+          - "12.4" # Swift 5.3
+          - "12.5" # Swift 5.4
+          - "13.0" # Swift 5.5
         command:
           - test
           - benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,33 @@ jobs:
         run: system_profiler SPHardwareDataType
       - name: Run ${{ matrix.command }}
         run: make ${{ matrix.command }}
+
+  windows_build:
+    runs-on: windows-2019
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: seanmiddleditch/gha-setup-vsdevenv@v3
+
+      - name: Install Swift 5.4
+        run: |
+          Install-Binary -Url "https://swift.org/builds/swift-5.4.2-release/windows10/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+      - name: Set Environment Variables
+        run: |
+          echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DEVELOPER_DIR=C:\Library\Developer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Adjust Paths
+        run: |
+          echo "C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install Supporting Files
+        run: |
+          Copy-Item "$env:SDKROOT\usr\share\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
+          Copy-Item "$env:SDKROOT\usr\share\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
+          Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
+          Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Benchmark",
         "repositoryURL": "https://github.com/google/swift-benchmark",
         "state": {
-          "branch": "main",
+          "branch": null,
           "revision": "a0564bf88df5f94eec81348a2f089494c6b28d80",
-          "version": null
+          "version": "0.1.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,17 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "83b23d940471b313427da226196661856f6ba3e0",
+          "version": "0.4.4"
         }
       },
       {
-        "package": "swift-benchmark",
-        "repositoryURL": "https://github.com/google/swift-benchmark",
+        "package": "Benchmark",
+        "repositoryURL": "https://github.com/MaxDesiatov/swift-benchmark",
         "state": {
-          "branch": null,
-          "revision": "8e0ef8bb7482ab97dcd2cd1d6855bd38921c345d",
-          "version": "0.1.0"
+          "branch": "swift-5.4-windows",
+          "revision": "eb8039c621fbcee725105d045db7aa11d832edd3",
+          "version": null
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,16 +6,16 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "83b23d940471b313427da226196661856f6ba3e0",
-          "version": "0.4.4"
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
         }
       },
       {
         "package": "Benchmark",
-        "repositoryURL": "https://github.com/MaxDesiatov/swift-benchmark",
+        "repositoryURL": "https://github.com/google/swift-benchmark",
         "state": {
-          "branch": "swift-5.4-windows",
-          "revision": "eb8039c621fbcee725105d045db7aa11d832edd3",
+          "branch": "main",
+          "revision": "a0564bf88df5f94eec81348a2f089494c6b28d80",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark",  from: "0.1.1")
+    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.1")
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", .branch("main")),
+    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark",  from: "0.1.1")
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "Benchmark", url: "https://github.com/MaxDesiatov/swift-benchmark", .branch("swift-5.4-windows")),
+    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", .branch("main")),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -8,10 +8,10 @@ let package = Package(
     .library(
       name: "Parsing",
       targets: ["Parsing"]
-    )
+    ),
   ],
   dependencies: [
-    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0")
+    .package(name: "Benchmark", url: "https://github.com/MaxDesiatov/swift-benchmark", .branch("swift-5.4-windows")),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     .library(
       name: "Parsing",
       targets: ["Parsing"]
-    ),
+    )
   ],
   dependencies: [
     .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark",  from: "0.1.1")

--- a/Sources/Parsing/Parsers/Double.swift
+++ b/Sources/Parsing/Parsers/Double.swift
@@ -290,11 +290,3 @@ extension Collection where SubSequence == Self, Element == UTF8.CodeUnit {
     return original[..<self.startIndex]
   }
 }
-
-#if os(Windows)
-  @usableFromInline
-  let cLocale: locale_t? = _create_locale(LC_ALL, "C")
-#else
-  @usableFromInline
-  let cLocale: locale_t? = nil
-#endif


### PR DESCRIPTION
Global `cLocale` constant was broken on Windows and was actually unused, it made sense to remove it.

Additionally, I've expanded macOS Xcode version matrix to include 12.4, 12.5, and 13.0 for testing with different Swift versions. Now all Xcode version values are quoted, since YAML automatically parses `13.0` as a number not a string, converting it to plain `13`, which breaks the build.

For testing on Windows I'm `MaxDesiatov/swift-windows-action` which invokes `swift test` automatically, but let me know if you'd like that to be more explicit.