### PR TITLE
correct typo in line 24

### DIFF
--- a/Sources/Parsing/Parsers/AnyParser.swift
+++ b/Sources/Parsing/Parsers/AnyParser.swift
@@ -21,7 +21,7 @@ extension Parser {
 /// This parser forwards its ``parse(_:)`` method to an arbitrary underlying parser having the same
 /// `Input` and `Output` types, hiding the specifics of the underlying ``Parser``.
 ///
-/// Use ``AnyParser`` to wrap a publisher whose type has details you don't want to expose across API
+/// Use ``AnyParser`` to wrap a parser whose type has details you don't want to expose across API
 /// boundaries, such as different modules. When you use type erasure this way, you can change the
 /// underlying parser over time without affecting existing clients.
 public struct AnyParser<Input, Output>: Parser {


### PR DESCRIPTION
There is a typo in line 24 "Use ``AnyParser`` to wrap a publisher whose..." - it might be parser, not publisher.