### PR TITLE
Clean up benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - "11.7"   # Swift 5.2
           - "12.4"   # Swift 5.3
           - "12.5.1" # Swift 5.4
           - "13.0"   # Swift 5.5

--- a/README.md
+++ b/README.md
@@ -314,46 +314,47 @@ MacBook Pro (16-inch, 2019)
 2.4 GHz 8-Core Intel Core i9
 64 GB 2667 MHz DDR4
 
-name                                         time             std        iterations
------------------------------------------------------------------------------------
-Arithmetic.Parser                                13291.000 ns ±  47.42 %      92380
-BinaryData.Parser                                  541.000 ns ± 201.34 %    1000000
-Bool.Bool.init                                      29.000 ns ± 618.75 %    1000000
-Bool.BoolParser                                     45.000 ns ± 697.67 %    1000000
-Bool.Scanner.scanBool                              866.000 ns ± 152.94 %    1000000
-Color.Parser                                       130.000 ns ± 362.56 %    1000000
-CSV.Parser                                     1370783.000 ns ±  11.26 %        987
-CSV.Ad hoc mutating methods                    1380702.000 ns ±  12.58 %        991
-Date.Parser                                      13026.000 ns ±  50.38 %      98904
-Date.DateFormatter                               42814.000 ns ±  41.11 %      30427
-Date.ISO8601DateFormatter                        57900.000 ns ±  37.00 %      21041
-HTTP.HTTP                                         4031.000 ns ±  83.99 %     314128
-JSON.Parser                                       6088.000 ns ±  65.76 %     210078
-JSON.JSONSerialization                            3361.000 ns ±  84.90 %     376928
-Numerics.Int.init                                   40.000 ns ± 639.27 %    1000000
-Numerics.Int.parser                                 42.000 ns ± 716.38 %    1000000
-Numerics.Scanner.scanInt                           146.000 ns ± 378.76 %    1000000
-Numerics.Comma separated: Int.parser           5390299.000 ns ±   5.52 %        253
-Numerics.Comma separated: Scanner.scanInt     86885256.500 ns ±   5.40 %         16
-Numerics.Comma separated: String.split       120884645.000 ns ±   2.18 %         11
-Numerics.Double.init                                62.000 ns ± 615.58 %    1000000
-Numerics.Double.parser                              92.000 ns ± 249.73 %    1000000
-Numerics.Scanner.scanDouble                        204.000 ns ± 301.13 %    1000000
-Numerics.Comma separated: Double.parser        8743220.000 ns ±   6.54 %        138
-Numerics.Comma separated: Scanner.scanDouble  90561940.000 ns ±   1.49 %         16
-Numerics.Comma separated: String.split        36217863.000 ns ±   4.66 %         39
-PrefixUpTo.Parser                                22917.000 ns ±  39.36 %      53264
-PrefixUpTo.Scanner.scanUpToString               166872.000 ns ±  23.59 %       7710
-Race.Parser                                      31445.000 ns ±  38.86 %      40463
-README Example.Parser: Substring                  3553.000 ns ±  80.09 %     337107
-README Example.Parser: UTF8                       1291.000 ns ± 124.36 %     912187
-README Example.Adhoc                              7952.000 ns ±  60.09 %     161835
-Routing.Parser                                    5362.000 ns ±  65.88 %     241853
-String Abstractions.Substring                  1102496.000 ns ±  11.32 %       1227
-String Abstractions.UTF8                        144420.000 ns ±  22.45 %       8905
-UUID.UUID.init                                     392.000 ns ± 256.71 %    1000000
-UUID.UUIDParser                                    154.000 ns ± 412.07 %    1000000
-Xcode Logs.Parser                              7369318.000 ns ±   5.83 %        190
+name                                         time            std        iterations
+----------------------------------------------------------------------------------
+Arithmetic.Parser                               12165.000 ns ±  41.54 %     103825
+BinaryData.Parser                                 476.000 ns ± 153.92 %    1000000
+Bool.Bool.init                                     31.000 ns ± 603.17 %    1000000
+Bool.BoolParser                                    59.000 ns ± 528.05 %    1000000
+Bool.Scanner.scanBool                             874.000 ns ± 106.43 %    1000000
+Color.Parser                                      342.000 ns ± 168.44 %    1000000
+CSV.Parser                                    2386368.000 ns ±  10.04 %        579
+CSV.Ad hoc mutating methods                   1234026.000 ns ±   9.69 %       1067
+Date.Parser                                     12592.000 ns ±  32.78 %     102725
+Date.DateFormatter                              45090.000 ns ±  26.36 %      29852
+Date.ISO8601DateFormatter                       59856.000 ns ±  22.87 %      21828
+HTTP.HTTP                                        7601.000 ns ±  27.66 %     179400
+JSON.Parser                                      9693.000 ns ±  34.53 %     136550
+JSON.JSONSerialization                           2817.000 ns ±  55.73 %     454250
+Numerics.Int.init                                  38.000 ns ± 562.01 %    1000000
+Numerics.Int.parser                                55.000 ns ± 296.14 %    1000000
+Numerics.Scanner.scanInt                          146.000 ns ± 263.77 %    1000000
+Numerics.Comma separated: Int.parser          7274398.000 ns ±   5.29 %        187
+Numerics.Comma separated: Scanner.scanInt    71464279.000 ns ±   2.03 %         19
+Numerics.Comma separated: String.split       19688849.000 ns ±   4.17 %         67
+Numerics.Double.init                               65.000 ns ± 521.65 %    1000000
+Numerics.Double.parser                            176.000 ns ± 222.19 %    1000000
+Numerics.Scanner.scanDouble                       215.000 ns ± 228.61 %    1000000
+Numerics.Comma separated: Double.parser      26425776.000 ns ±   3.62 %         51
+Numerics.Comma separated: Scanner.scanDouble 79813919.000 ns ±   9.20 %         17
+Numerics.Comma separated: String.split       24996816.000 ns ±   7.69 %         56
+PrefixUpTo.Parser                               21480.000 ns ±  31.23 %      61003
+PrefixUpTo.Scanner.scanUpToString              146144.000 ns ±  19.82 %       9061
+Race.Parser                                     50712.000 ns ±  26.27 %      26304
+README Example.Parser: Substring                 3371.000 ns ±  48.81 %     350548
+README Example.Parser: UTF8                      1450.000 ns ±  73.15 %     887247
+README Example.Adhoc                             4816.000 ns ±  46.36 %     272970
+README Example.Scanner                          19047.000 ns ±  28.09 %      66475
+Routing.Parser                                   4958.000 ns ±  41.54 %     272198
+String Abstractions.Substring                  919339.000 ns ±  16.15 %       1469
+String Abstractions.UTF8                        62634.000 ns ±  18.92 %      20889
+UUID.UUID.init                                    332.000 ns ± 153.80 %    1000000
+UUID.UUIDParser                                   467.000 ns ± 154.38 %    1000000
+Xcode Logs.Parser                             6251988.500 ns ±   5.45 %        218
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ Bool.Bool.init                                     31.000 ns ± 603.17 %    1000
 Bool.BoolParser                                    59.000 ns ± 528.05 %    1000000
 Bool.Scanner.scanBool                             874.000 ns ± 106.43 %    1000000
 Color.Parser                                      342.000 ns ± 168.44 %    1000000
-CSV.Parser                                    2386368.000 ns ±  10.04 %        579
-CSV.Ad hoc mutating methods                   1234026.000 ns ±   9.69 %       1067
+CSV.Parser                                    1884886.500 ns ±  10.04 %        694
+CSV.Ad hoc mutating methods                   1229682.000 ns ±   9.69 %       1069
 Date.Parser                                     12592.000 ns ±  32.78 %     102725
 Date.DateFormatter                              45090.000 ns ±  26.36 %      29852
 Date.ISO8601DateFormatter                       59856.000 ns ±  22.87 %      21828

--- a/Sources/swift-parsing-benchmark/Bool.swift
+++ b/Sources/swift-parsing-benchmark/Bool.swift
@@ -21,7 +21,7 @@ let boolSuite = BenchmarkSuite(name: "Bool") { suite in
 
   suite.benchmark(
     name: "BoolParser",
-    run: { output = Bool.parser(of: Slice<UnsafeBufferPointer<UTF8.CodeUnit>>.self).parse(input) },
+    run: { output = Bool.parser(of: Substring.UTF8View.self).parse(input) },
     tearDown: { precondition(output == expected) }
   )
 

--- a/Sources/swift-parsing-benchmark/CSV/CSVBenchmarks.swift
+++ b/Sources/swift-parsing-benchmark/CSV/CSVBenchmarks.swift
@@ -9,26 +9,20 @@ import Parsing
 
 // MARK: - Parser
 
-private struct CSV: Parser {
-  func parse(_ input: inout Substring.UTF8View) -> [[String]]? {
-    let plainField = Prefix {
-      $0 != .init(ascii: ",") && $0 != .init(ascii: "\n")
-    }
-
-    let quotedField = "\"".utf8
-      .take(Prefix { $0 != .init(ascii: "\"") })
-      .skip("\"".utf8)
-
-    let field = quotedField.orElse(plainField)
-      .map { String(Substring($0)) }
-
-    let line = Many(field, separator: ",".utf8)
-
-    let csv = Many(line, separator: "\n".utf8)
-
-    return csv.parse(&input)
-  }
+private let plainField = Prefix {
+  $0 != .init(ascii: ",") && $0 != .init(ascii: "\n")
 }
+
+private let quotedField = "\"".utf8
+  .take(Prefix { $0 != .init(ascii: "\"") })
+  .skip("\"".utf8)
+
+private let field = quotedField.orElse(plainField)
+  .map { String(Substring($0)) }
+
+private let line = Many(field, separator: ",".utf8)
+
+private let csv = Many(line, separator: "\n".utf8)
 
 // MARK: - Ad hoc mutating methods
 
@@ -91,7 +85,6 @@ let csvSuite = BenchmarkSuite(name: "CSV") { suite in
   let columnCount = 5
   var output: [[String]] = []
 
-  let csv = CSV()
   suite.benchmark(
     name: "Parser",
     run: {

--- a/Sources/swift-parsing-benchmark/CSV/CSVBenchmarks.swift
+++ b/Sources/swift-parsing-benchmark/CSV/CSVBenchmarks.swift
@@ -18,7 +18,8 @@ private let quotedField = "\"".utf8
   .skip("\"".utf8)
 
 private let field = quotedField.orElse(plainField)
-  .map { String(Substring($0)) }
+  .map { String(decoding: $0, as: UTF8.self) }
+//  .map { String(Substring($0)) }
 
 private let line = Many(field, separator: ",".utf8)
 

--- a/Sources/swift-parsing-benchmark/CSV/CSVBenchmarks.swift
+++ b/Sources/swift-parsing-benchmark/CSV/CSVBenchmarks.swift
@@ -2,58 +2,33 @@ import Benchmark
 import Foundation
 import Parsing
 
-//name                 time           std        iterations
-//---------------------------------------------------------
-//CSV.Parser           1245858.500 ns ±  10.38 %       1090
-//CSV.Mutating methods 1309019.000 ns ±   8.27 %       1060
-
-let csvSuite = BenchmarkSuite(name: "CSV") { suite in
-  let rowCount = 1_000
-  let columnCount = 5
-  var output: [[String]] = []
-
-  suite.benchmark(
-    name: "Parser",
-    run: {
-      output = csv.parse(csvInput)!
-    },
-    tearDown: {
-      precondition(output.count == rowCount)
-      precondition(output.allSatisfy { $0.count == columnCount })
-    }
-  )
-
-  suite.benchmark(
-    name: "Ad hoc mutating methods",
-    run: {
-      var input = csvInput[...].utf8
-      output = input.parseCsv()
-    },
-    tearDown: {
-      precondition(output.count == rowCount)
-      precondition(output.allSatisfy { $0.count == columnCount })
-    }
-  )
-}
+//name                        time           std        iterations
+//----------------------------------------------------------------
+//CSV.Parser                  1884886.500 ns ±  13.14 %        694
+//CSV.Ad hoc mutating methods 1229682.000 ns ±  12.79 %       1069
 
 // MARK: - Parser
 
-private typealias Input = Slice<UnsafeBufferPointer<UTF8.CodeUnit>>
+private struct CSV: Parser {
+  func parse(_ input: inout Substring.UTF8View) -> [[String]]? {
+    let plainField = Prefix {
+      $0 != .init(ascii: ",") && $0 != .init(ascii: "\n")
+    }
 
-private let plainField = Prefix<Input> {
-  $0 != .init(ascii: ",") && $0 != .init(ascii: "\n")
+    let quotedField = "\"".utf8
+      .take(Prefix { $0 != .init(ascii: "\"") })
+      .skip("\"".utf8)
+
+    let field = quotedField.orElse(plainField)
+      .map { String(Substring($0)) }
+
+    let line = Many(field, separator: ",".utf8)
+
+    let csv = Many(line, separator: "\n".utf8)
+
+    return csv.parse(&input)
+  }
 }
-
-private let quotedField = Skip(StartsWith<Input>("\"".utf8))
-  .take(Prefix { $0 != .init(ascii: "\"") })
-  .skip(StartsWith("\"".utf8))
-
-private let field = quotedField.orElse(plainField)
-  .map { String(decoding: $0, as: UTF8.self) }
-
-private let line = Many(field, separator: StartsWith(",".utf8))
-
-private let csv = Many(line, separator: StartsWith("\n".utf8))
 
 // MARK: - Ad hoc mutating methods
 
@@ -107,4 +82,36 @@ extension Substring.UTF8View {
     self.removeFirst(prefix.count)
     return prefix
   }
+}
+
+// MARK: - Suite
+
+let csvSuite = BenchmarkSuite(name: "CSV") { suite in
+  let rowCount = 1_000
+  let columnCount = 5
+  var output: [[String]] = []
+
+  let csv = CSV()
+  suite.benchmark(
+    name: "Parser",
+    run: {
+      output = csv.parse(csvInput)!
+    },
+    tearDown: {
+      precondition(output.count == rowCount)
+      precondition(output.allSatisfy { $0.count == columnCount })
+    }
+  )
+
+  suite.benchmark(
+    name: "Ad hoc mutating methods",
+    run: {
+      var input = csvInput[...].utf8
+      output = input.parseCsv()
+    },
+    tearDown: {
+      precondition(output.count == rowCount)
+      precondition(output.allSatisfy { $0.count == columnCount })
+    }
+  )
 }

--- a/Sources/swift-parsing-benchmark/Color.swift
+++ b/Sources/swift-parsing-benchmark/Color.swift
@@ -5,13 +5,10 @@ private struct Color: Equatable {
   let red, green, blue: UInt8
 }
 
-private typealias Input = Slice<UnsafeBufferPointer<UInt8>>
-private typealias Output = Color
+private let hexPrimary = Prefix(2)
+  .pipe(UInt8.parser(of: Substring.UTF8View.self, isSigned: false, radix: 16).skip(End()))
 
-private let hexPrimary = Prefix<Input>(2)
-  .pipe(UInt8.parser(isSigned: false, radix: 16).skip(End()))
-
-private let hexColor = StartsWith("#".utf8)
+private let hexColor = "#".utf8
   .take(hexPrimary)
   .take(hexPrimary)
   .take(hexPrimary)
@@ -20,7 +17,7 @@ private let hexColor = StartsWith("#".utf8)
 let colorSuite = BenchmarkSuite(name: "Color") { suite in
   let input = "#FF0000"
   let expected = Color(red: 0xFF, green: 0x00, blue: 0x00)
-  var output: Output!
+  var output: Color!
 
   suite.benchmark(
     name: "Parser",

--- a/Sources/swift-parsing-benchmark/Date.swift
+++ b/Sources/swift-parsing-benchmark/Date.swift
@@ -19,45 +19,43 @@ import Parsing
 
 // MARK: - Parser
 
-private typealias Input = Slice<UnsafeBufferPointer<UInt8>>
-
 private let dateTime =
   offsetDateTime
   .orElse(localDateTime)
   .orElse(localDate)
   .orElse(localTime)
 
-private let dateFullyear = Prefix<Input>(4).pipe(Int.parser().skip(End()))
-private let dateMonth = Prefix<Input>(2).pipe(Int.parser().skip(End()))
-private let dateMday = Prefix<Input>(2).pipe(Int.parser().skip(End()))
-private let timeDelim = OneOfMany<StartsWith<Input>>(
-  StartsWith("T".utf8), StartsWith("t".utf8), StartsWith(" ".utf8)
-)
-private let timeHour = Prefix<Input>(2).pipe(Int.parser().skip(End()))
-private let timeMinute = Prefix<Input>(2).pipe(Int.parser().skip(End()))
-private let timeSecond = Prefix<Input>(2).pipe(Int.parser().skip(End()))
-private let nanoSecfrac = Prefix<Input>
-  .init(while: (.init(ascii: "0") ... .init(ascii: "9")).contains)
+private let digits = { (n: Int) in Prefix<Substring.UTF8View>(n).pipe(Int.parser().skip(End())) }
+
+private let dateFullyear = digits(4)
+private let dateMonth = digits(2)
+private let dateMday = digits(2)
+private let timeDelim = OneOfMany("T".utf8, "t".utf8, " ".utf8)
+
+private let timeHour = digits(2)
+private let timeMinute = digits(2)
+private let timeSecond = digits(2)
+private let nanoSecfrac = Prefix(while: (.init(ascii: "0") ... .init(ascii: "9")).contains)
   .map { $0.prefix(9) }
-private let timeSecfrac = StartsWith(".".utf8).take(nanoSecfrac)
+private let timeSecfrac = ".".utf8.take(nanoSecfrac)
   .compactMap { n in
     Int(String(decoding: n, as: UTF8.self))
       .map { $0 * Int(pow(10, 9 - Double(n.count))) }
   }
-private let timeNumoffset = StartsWith("+".utf8).map { 1 }.orElse(StartsWith("-".utf8).map { -1 })
-  .take(timeHour).skip(StartsWith(":".utf8))
+private let timeNumoffset = "+".utf8.map { 1 }.orElse("-".utf8.map { -1 })
+  .take(timeHour).skip(":".utf8)
   .take(timeMinute)
-private let timeOffset = StartsWith("Z".utf8).map { (sign: 1, minute: 0, second: 0) }
+private let timeOffset = "Z".utf8.map { (sign: 1, minute: 0, second: 0) }
   .orElse(timeNumoffset)
   .compactMap { TimeZone(secondsFromGMT: $0 * ($1 * 60 + $2)) }
 
-private let partialTime = timeHour.skip(StartsWith(":".utf8))
-  .take(timeMinute).skip(StartsWith(":".utf8))
-  .take(timeSecond)
+private let partialTime = timeHour
+  .skip(":".utf8).take(timeMinute)
+  .skip(":".utf8).take(timeSecond)
   .take(Optional.parser(of: timeSecfrac))
-private let fullDate = dateFullyear.skip(StartsWith("-".utf8))
-  .take(dateMonth).skip(StartsWith("-".utf8))
-  .take(dateMday)
+private let fullDate = dateFullyear
+  .skip("-".utf8).take(dateMonth)
+  .skip("-".utf8).take(dateMday)
 private let fullTime = partialTime.take(timeOffset)
 
 private let offsetDateTime = fullDate.skip(timeDelim).take(fullTime)

--- a/Sources/swift-parsing-benchmark/Numerics.swift
+++ b/Sources/swift-parsing-benchmark/Numerics.swift
@@ -34,7 +34,7 @@ let numericsSuite = BenchmarkSuite(name: "Numerics") { suite in
 
     suite.benchmark(
       name: "Int.parser",
-      run: { output = Int.parser(of: Slice<UnsafeBufferPointer<UTF8.CodeUnit>>.self).parse(input) },
+      run: { output = Int.parser(of: Substring.UTF8View.self).parse(input) },
       tearDown: { precondition(output == expected) }
     )
 
@@ -54,10 +54,7 @@ let numericsSuite = BenchmarkSuite(name: "Numerics") { suite in
     let expected = Array(1...100_000)
     var output: [Int]!
 
-    let parser = Many(
-      Int.parser(of: Slice<UnsafeBufferPointer<UTF8.CodeUnit>>.self),
-      separator: StartsWith(",".utf8)
-    )
+    let parser = Many(Int.parser(), separator: ",".utf8)
     suite.benchmark(
       name: "Comma separated: Int.parser",
       run: { output = parser.parse(input) },
@@ -105,7 +102,7 @@ let numericsSuite = BenchmarkSuite(name: "Numerics") { suite in
     suite.benchmark(
       name: "Double.parser",
       run: {
-        output = Double.parser(of: Slice<UnsafeBufferPointer<UTF8.CodeUnit>>.self).parse(input)
+        output = Double.parser(of: Substring.UTF8View.self).parse(input)
       },
       tearDown: { precondition(output == expected) }
     )
@@ -126,10 +123,7 @@ let numericsSuite = BenchmarkSuite(name: "Numerics") { suite in
     let expected = (1...100_000).map(Double.init)
     var output: [Double]!
 
-    let parser = Many(
-      Double.parser(of: Slice<UnsafeBufferPointer<UTF8.CodeUnit>>.self),
-      separator: StartsWith(",".utf8)
-    )
+    let parser = Many(Double.parser(), separator: ",".utf8)
     suite.benchmark(
       name: "Comma separated: Double.parser",
       run: { output = parser.parse(input) },

--- a/Sources/swift-parsing-benchmark/UUID.swift
+++ b/Sources/swift-parsing-benchmark/UUID.swift
@@ -15,7 +15,7 @@ let uuidSuite = BenchmarkSuite(name: "UUID") { suite in
 
   suite.benchmark(
     name: "UUIDParser",
-    run: { output = UUID.parser(of: Slice<UnsafeBufferPointer<UTF8.CodeUnit>>.self).parse(input) },
+    run: { output = UUID.parser(of: Substring.UTF8View.self).parse(input) },
     tearDown: { precondition(output == expected) }
   )
 }


### PR DESCRIPTION
This work based on a discussion we had earlier. Our benchmarks were not quite real world in the sense that they worked with unsafe buffer pointers. While it might be a good idea to eke out every last bit of performance with an unsafe pointer, our benchmarks should maybe err on the side of typical library use instead. As a consequence, this PR also cleans up how these parsers are defined.