### PR TITLE
Improve double parsing logic

### DIFF
--- a/Sources/Parsing/Parsers/Double.swift
+++ b/Sources/Parsing/Parsers/Double.swift
@@ -257,27 +257,26 @@ extension Collection where SubSequence == Self, Element == UTF8.CodeUnit {
     if self.first == .init(ascii: "-") || self.first == .init(ascii: "+") {
       self.removeFirst()
     }
-    while let c = self.first, (.init(ascii: "0") ... .init(ascii: "9")).contains(c) {
-      self.removeFirst()
-    }
+    let integer = self.prefix(while: (.init(ascii: "0") ... .init(ascii: "9")).contains)
+    guard !integer.isEmpty else { return nil }
+    self.removeFirst(integer.count)
     if self.first == .init(ascii: ".") {
-      self.removeFirst()
-      while let c = self.first, (.init(ascii: "0") ... .init(ascii: "9")).contains(c) {
-        self.removeFirst()
-      }
-    }
-    guard self.startIndex != original.startIndex else {
-      self = original
-      return nil
+      let fractional = self
+        .dropFirst()
+        .prefix(while: (.init(ascii: "0") ... .init(ascii: "9")).contains)
+      guard !fractional.isEmpty else { return original[..<self.startIndex] }
+      self.removeFirst(1 + fractional.count)
     }
     if self.first == .init(ascii: "e") || self.first == .init(ascii: "E") {
-      self.removeFirst()
-      if self.first == .init(ascii: "-") || self.first == .init(ascii: "+") {
-        self.removeFirst()
+      var n = 1
+      if self.dropFirst().first == .init(ascii: "-") || self.first == .init(ascii: "+") {
+        n += 1
       }
-      while let c = self.first, (.init(ascii: "0") ... .init(ascii: "9")).contains(c) {
-        self.removeFirst()
-      }
+      let exponent = self
+        .dropFirst(n)
+        .prefix(while: (.init(ascii: "0") ... .init(ascii: "9")).contains)
+      guard !exponent.isEmpty else { return original[..<self.startIndex] }
+      self.removeFirst(n + exponent.count)
     }
     return original[..<self.startIndex]
   }

--- a/Tests/ParsingTests/DoubleTests.swift
+++ b/Tests/ParsingTests/DoubleTests.swift
@@ -11,7 +11,7 @@ final class DoubleTests: XCTestCase {
 
     input = "123. Hello"[...].utf8
     XCTAssertEqual(123, parser.parse(&input))
-    XCTAssertEqual(" Hello", String(input))
+    XCTAssertEqual(". Hello", String(input))
 
     input = "123.123 Hello"[...].utf8
     XCTAssertEqual(123.123, parser.parse(&input))
@@ -28,6 +28,10 @@ final class DoubleTests: XCTestCase {
     input = "123E-2 Hello"[...].utf8
     XCTAssertEqual(123E-2, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
+
+    input = "123E Hello"[...].utf8
+    XCTAssertEqual(123, parser.parse(&input))
+    XCTAssertEqual("E Hello", String(input))
 
     input = "1234567890123456789012345678901234567890 Hello"[...].utf8
     XCTAssertEqual(1_234_567_890_123_456_846_996_462_118_072_609_669_120, parser.parse(&input))
@@ -63,7 +67,7 @@ final class DoubleTests: XCTestCase {
 
     input = "123. Hello"[...].utf8
     XCTAssertEqual(123, parser.parse(&input))
-    XCTAssertEqual(" Hello", String(input))
+    XCTAssertEqual(". Hello", String(input))
 
     input = "123.123 Hello"[...].utf8
     XCTAssertEqual(123.123, parser.parse(&input))
@@ -80,6 +84,10 @@ final class DoubleTests: XCTestCase {
     input = "123E-2 Hello"[...].utf8
     XCTAssertEqual(123E-2, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
+
+    input = "123E Hello"[...].utf8
+    XCTAssertEqual(123, parser.parse(&input))
+    XCTAssertEqual("E Hello", String(input))
 
     input = "1234567890123456789012345678901234567890 Hello"[...].utf8
     let parsed = parser.parse(&input)
@@ -121,7 +129,7 @@ final class DoubleTests: XCTestCase {
 
       input = "123. Hello"[...].utf8
       XCTAssertEqual(123, parser.parse(&input))
-      XCTAssertEqual(" Hello", String(input))
+      XCTAssertEqual(". Hello", String(input))
 
       input = "123.123 Hello"[...].utf8
       XCTAssertEqual(123.123, parser.parse(&input))
@@ -138,6 +146,10 @@ final class DoubleTests: XCTestCase {
       input = "123E-2 Hello"[...].utf8
       XCTAssertEqual(123E-2, parser.parse(&input))
       XCTAssertEqual(" Hello", String(input))
+
+      input = "123E Hello"[...].utf8
+      XCTAssertEqual(123, parser.parse(&input))
+      XCTAssertEqual("E Hello", String(input))
 
       input = "1234567890123456789012345678901234567890 Hello"[...].utf8
       XCTAssertEqual(1_234_567_890_123_456_788_999_898_750_329_779_388_416, parser.parse(&input))

--- a/Tests/ParsingTests/DoubleTests.swift
+++ b/Tests/ParsingTests/DoubleTests.swift
@@ -45,6 +45,10 @@ final class DoubleTests: XCTestCase {
     XCTAssertEqual(123, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
 
+    input = "-.123 Hello"[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual("-.123 Hello", String(input))
+
     input = "Hello"[...].utf8
     XCTAssertEqual(nil, parser.parse(&input))
     XCTAssertEqual("Hello", String(input))
@@ -106,6 +110,10 @@ final class DoubleTests: XCTestCase {
     XCTAssertEqual(123, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
 
+    input = "-.123 Hello"[...].utf8
+    XCTAssertEqual(nil, parser.parse(&input))
+    XCTAssertEqual("-.123 Hello", String(input))
+
     input = "Hello"[...].utf8
     XCTAssertEqual(nil, parser.parse(&input))
     XCTAssertEqual("Hello", String(input))
@@ -162,6 +170,10 @@ final class DoubleTests: XCTestCase {
       input = "+123 Hello"[...].utf8
       XCTAssertEqual(123, parser.parse(&input))
       XCTAssertEqual(" Hello", String(input))
+
+      input = "-.123 Hello"[...].utf8
+      XCTAssertEqual(nil, parser.parse(&input))
+      XCTAssertEqual("-.123 Hello", String(input))
 
       input = "Hello"[...].utf8
       XCTAssertEqual(nil, parser.parse(&input))


### PR DESCRIPTION
After #66 came in I reread the existing logic and think it's maybe a bit too loose. It does its best to consume what it thinks may be a valid sub-sequence and then passes the result to `Double.init`.

I think we should be more careful what we pass to `Double.init`. Right now we allow for the following things to get passed over:

  - `"-.1" -> -0.1`
    This may not be problematic, but it's not even a valid Swift literal. Maybe we should be more strict and always require the integer when there's a fractional part?
  - `"+1." -> 1.0`
    This is more problematic: we consume the period, which may not be intended.
  - `"1e" -> nil`
    I'd consider this a current bug. We should probably consume `1` as `1.0` and then leave the `e` unconsumed.

Beyond those cases, there are things that `Double.init` parses that are just strange:

  - `"0xf" -> 15.0`

This PR updates the logic to be a bit more deliberate:

1. Try to parse a `+`/`-`
2. Parse out an integer, or fail
3. If there's a `.`, try to parse out a fractional component, or return what's consumed
4. If there's an `e`/`E`, try to parse out an exponent component, or return what's consumed
5. Return what's consumed

This is technically a breaking change (`1.` and `.1` are no longer "valid" doubles), but I think worth it...