### PR TITLE
Fix parsing of floats with scientific notation

### DIFF
--- a/Sources/Parsing/Parsers/Double.swift
+++ b/Sources/Parsing/Parsers/Double.swift
@@ -270,7 +270,7 @@ extension Collection where SubSequence == Self, Element == UTF8.CodeUnit {
     }
     if self.first == .init(ascii: "e") || self.first == .init(ascii: "E") {
       var n = 1
-      if self.dropFirst().first == .init(ascii: "-") || self.first == .init(ascii: "+") {
+      if self.dropFirst().first == .init(ascii: "-") || self.dropFirst().first == .init(ascii: "+") {
         n += 1
       }
       let exponent =

--- a/Tests/ParsingTests/DoubleTests.swift
+++ b/Tests/ParsingTests/DoubleTests.swift
@@ -25,8 +25,16 @@ final class DoubleTests: XCTestCase {
     XCTAssertEqual(123.123E-2, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
 
+    input = "123.123E+2 Hello"[...].utf8
+    XCTAssertEqual(123.123E+2, parser.parse(&input))
+    XCTAssertEqual(" Hello", String(input))
+
     input = "123E-2 Hello"[...].utf8
     XCTAssertEqual(123E-2, parser.parse(&input))
+    XCTAssertEqual(" Hello", String(input))
+
+    input = "123E+2 Hello"[...].utf8
+    XCTAssertEqual(123E+2, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
 
     input = "123E Hello"[...].utf8
@@ -85,8 +93,16 @@ final class DoubleTests: XCTestCase {
     XCTAssertEqual(123.123E-2, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
 
+    input = "123.123E+2 Hello"[...].utf8
+    XCTAssertEqual(123.123E+2, parser.parse(&input))
+    XCTAssertEqual(" Hello", String(input))
+
     input = "123E-2 Hello"[...].utf8
     XCTAssertEqual(123E-2, parser.parse(&input))
+    XCTAssertEqual(" Hello", String(input))
+
+    input = "123E+2 Hello"[...].utf8
+    XCTAssertEqual(123E+2, parser.parse(&input))
     XCTAssertEqual(" Hello", String(input))
 
     input = "123E Hello"[...].utf8
@@ -151,8 +167,16 @@ final class DoubleTests: XCTestCase {
       XCTAssertEqual(123.123E-2, parser.parse(&input))
       XCTAssertEqual(" Hello", String(input))
 
+      input = "123.123E+2 Hello"[...].utf8
+      XCTAssertEqual(123.123E+2, parser.parse(&input))
+      XCTAssertEqual(" Hello", String(input))
+
       input = "123E-2 Hello"[...].utf8
       XCTAssertEqual(123E-2, parser.parse(&input))
+      XCTAssertEqual(" Hello", String(input))
+
+      input = "123E+2 Hello"[...].utf8
+      XCTAssertEqual(123E+2, parser.parse(&input))
       XCTAssertEqual(" Hello", String(input))
 
       input = "123E Hello"[...].utf8


### PR DESCRIPTION
The parsing currently fails when the `"E"` is followed by a `"+"`, because the `"E"` is not dropped before checking for that character.