### PR TITLE
Check if `Many`'s `Upstream` is consuming its `Collection` `Input`

### DIFF
--- a/Sources/Parsing/Parsers/Many.swift
+++ b/Sources/Parsing/Parsers/Many.swift
@@ -39,7 +39,9 @@ where
   public let separator: Separator?
   public let updateAccumulatingResult: (inout Result, Upstream.Output) -> Void
   public let upstream: Upstream
-
+  @usableFromInline
+  internal let upstreamDidConsumeInput: ((_ input: Upstream.Input, _ rest: Upstream.Input) -> Bool)?
+  
   /// Initializes a parser that attempts to run the given parser at least and at most the given
   /// number of times, accumulating the outputs into a result with a given closure.
   ///
@@ -66,6 +68,36 @@ where
     self.separator = separator
     self.updateAccumulatingResult = updateAccumulatingResult
     self.upstream = upstream
+    self.upstreamDidConsumeInput = nil
+  }
+  
+  /// Initializes a parser that attempts to run the given parser at least and at most the given
+  /// number of times, accumulating the outputs into a result with a given closure.
+  ///
+  /// - Parameters:
+  ///   - upstream: Another parser.
+  ///   - minimum: The minimum number of times to run this parser and consider parsing to be
+  ///     successful.
+  ///   - maximum: The maximum number of times to run this parser before returning the output.
+  ///   - separator: A parser that consumes input between each parsed output.
+  ///   - updateAccumulatingResult: A closure that updates the accumulating result with each output
+  ///     of the upstream parser.
+  @inlinable
+  public init(
+    _ upstream: Upstream,
+    into initialResult: Result,
+    atLeast minimum: Int = 0,
+    atMost maximum: Int = .max,
+    separator: Separator,
+    _ updateAccumulatingResult: @escaping (inout Result, Upstream.Output) -> Void
+  ) where Upstream.Input: Collection {
+    self.initialResult = initialResult
+    self.maximum = maximum
+    self.minimum = minimum
+    self.separator = separator
+    self.updateAccumulatingResult = updateAccumulatingResult
+    self.upstream = upstream
+    self.upstreamDidConsumeInput = { $0.startIndex != $1.startIndex }
   }
 
   @inlinable
@@ -75,6 +107,14 @@ where
     var result = self.initialResult
     var count = 0
     while count < self.maximum, let output = self.upstream.parse(&input) {
+      guard upstreamDidConsumeInput?(input, rest) != false else {
+        if count == 0 {
+          input = original
+          return nil
+        } else {
+          break
+        }
+      }
       count += 1
       rest = input
       self.updateAccumulatingResult(&result, output)
@@ -114,6 +154,25 @@ extension Many where Result == [Upstream.Output], Separator == Always<Input, Voi
       $0.append($1)
     }
   }
+  
+  /// Initializes a parser that attempts to run the given parser at least and at most the given
+  /// number of times, accumulating the outputs in an array.
+  ///
+  /// - Parameters:
+  ///   - upstream: Another parser.
+  ///   - minimum: The minimum number of times to run this parser and consider parsing to be
+  ///     successful.
+  ///   - maximum: The maximum number of times to run this parser before returning the output.
+  @inlinable
+  public init(
+    _ upstream: Upstream,
+    atLeast minimum: Int = 0,
+    atMost maximum: Int = .max
+  ) where Upstream.Input: Collection {
+    self.init(upstream, into: [], atLeast: minimum, atMost: maximum) {
+      $0.append($1)
+    }
+  }
 }
 
 extension Many where Result == [Upstream.Output] {
@@ -137,10 +196,30 @@ extension Many where Result == [Upstream.Output] {
       $0.append($1)
     }
   }
+  
+  /// Initializes a parser that attempts to run the given parser at least and at most the given
+  /// number of times, accumulating the outputs in an array.
+  ///
+  /// - Parameters:
+  ///   - upstream: Another parser.
+  ///   - minimum: The minimum number of times to run this parser and consider parsing to be
+  ///     successful.
+  ///   - maximum: The maximum number of times to run this parser before returning the output.
+  ///   - separator: A parser that consumes input between each parsed output.
+  @inlinable
+  public init(
+    _ upstream: Upstream,
+    atLeast minimum: Int = 0,
+    atMost maximum: Int = .max,
+    separator: Separator
+  ) where Upstream.Input: Collection {
+    self.init(upstream, into: [], atLeast: minimum, atMost: maximum, separator: separator) {
+      $0.append($1)
+    }
+  }
 }
 
 extension Many where Separator == Always<Input, Void> {
-
   /// Initializes a parser that attempts to run the given parser at least and at most the given
   /// number of times, accumulating the outputs into a result with a given closure.
   ///
@@ -165,6 +244,34 @@ extension Many where Separator == Always<Input, Void> {
     self.separator = nil
     self.updateAccumulatingResult = updateAccumulatingResult
     self.upstream = upstream
+    self.upstreamDidConsumeInput = nil
+  }
+  
+  /// Initializes a parser that attempts to run the given parser at least and at most the given
+  /// number of times, accumulating the outputs into a result with a given closure.
+  ///
+  /// - Parameters:
+  ///   - upstream: Another parser.
+  ///   - minimum: The minimum number of times to run this parser and consider parsing to be
+  ///     successful.
+  ///   - maximum: The maximum number of times to run this parser before returning the output.
+  ///   - updateAccumulatingResult: A closure that updates the accumulating result with each output
+  ///     of the upstream parser.
+  @inlinable
+  public init(
+    _ upstream: Upstream,
+    into initialResult: Result,
+    atLeast minimum: Int = 0,
+    atMost maximum: Int = .max,
+    _ updateAccumulatingResult: @escaping (inout Result, Upstream.Output) -> Void
+  ) where Upstream.Input: Collection {
+    self.initialResult = initialResult
+    self.maximum = maximum
+    self.minimum = minimum
+    self.separator = nil
+    self.updateAccumulatingResult = updateAccumulatingResult
+    self.upstream = upstream
+    self.upstreamDidConsumeInput = { $0.startIndex != $1.startIndex }
   }
 }
 

--- a/Tests/ParsingTests/ManyTests.swift
+++ b/Tests/ParsingTests/ManyTests.swift
@@ -89,4 +89,20 @@ class ManyTests: XCTestCase {
     )
     XCTAssertEqual(Substring(input), "")
   }
+  
+  func testFailureIfNoProgress() {
+    var input = " Hello, World!"[...]
+    XCTAssertNil(
+      Many(CharacterSet.alphanumerics).parse(&input)
+    )
+  }
+  
+  func testSuccessThenNoProgress() {
+    var input = "Hello, World!"[...]
+    XCTAssertEqual(
+      Many(CharacterSet.alphanumerics).parse(&input),
+      ["Hello"]
+    )
+    XCTAssertEqual(Substring(input), ", World!")
+  }
 }

--- a/Tests/ParsingTests/ManyTests.swift
+++ b/Tests/ParsingTests/ManyTests.swift
@@ -92,8 +92,9 @@ class ManyTests: XCTestCase {
   
   func testFailureIfNoProgress() {
     var input = " Hello, World!"[...]
-    XCTAssertNil(
-      Many(CharacterSet.alphanumerics).parse(&input)
+    XCTAssertEqual(
+      Many(CharacterSet.alphanumerics).parse(&input),
+      [""]
     )
   }
   
@@ -104,5 +105,14 @@ class ManyTests: XCTestCase {
       ["Hello"]
     )
     XCTAssertEqual(Substring(input), ", World!")
+  }
+  
+  func testSuccessesIntertwinedWithNoProgress() {
+    var input = "2001:db8:::2:1"[...]
+    XCTAssertEqual(
+      Many(CharacterSet.alphanumerics, separator: ":").parse(&input),
+      ["2001", "db8", "", "", "2", "1"]
+    )
+    XCTAssertEqual(Substring(input), "")
   }
 }


### PR DESCRIPTION
Here is a possible solution to the problem discussed in #72.
When the `Upstream.Input` of a `Many` parser is a `Collection`, the library checks that `input` is consumed in order to avoid infinite loops when the upstream parser can succeed without consuming the input.

For performance reasons, it checks that the `input.startIndex` is evolving when `input` is parsed. I'm not 100% sure it doesn't have edge cases with reversed collections or things like that. There's maybe a better property to check.

I don't know if it can work with `Sequence`'s, using another property.

This unfortunately leads to some code duplication for the public API's in order to branch into the correct initializers.

I'm using an optional block because I suspect it is faster to check than to evaluate one block that always returns `true` when input is not a `Collection`. This should be benchmarked, I guess.