### PR TITLE
Use memcmp to short-circuit Many when input isn't consumed

### DIFF
--- a/Sources/Parsing/Internal/Breakpoint.swift
+++ b/Sources/Parsing/Internal/Breakpoint.swift
@@ -33,6 +33,6 @@ func breakpoint(_ message: @autoclosure () -> String = "") {
       raise(SIGTRAP)
     }
   #else
-    assertionFailure(message)
+    assertionFailure(message())
   #endif
 }

--- a/Sources/Parsing/Internal/Breakpoint.swift
+++ b/Sources/Parsing/Internal/Breakpoint.swift
@@ -1,5 +1,9 @@
+import Foundation
+
 /// Raises a debug breakpoint if a debugger is attached.
-@inline(__always) func breakpoint(_ message: @autoclosure () -> String = "") {
+@inline(__always)
+@usableFromInline
+func breakpoint(_ message: @autoclosure () -> String = "") {
   #if DEBUG
     // https://github.com/bitstadium/HockeySDK-iOS/blob/c6e8d1e940299bec0c0585b1f7b86baf3b17fc82/Classes/BITHockeyHelper.m#L346-L370
     var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]

--- a/Sources/Parsing/Internal/Breakpoint.swift
+++ b/Sources/Parsing/Internal/Breakpoint.swift
@@ -1,10 +1,12 @@
-import Foundation
+#if canImport(Darwin)
+  import Darwin
+#endif
 
 /// Raises a debug breakpoint if a debugger is attached.
 @inline(__always)
 @usableFromInline
 func breakpoint(_ message: @autoclosure () -> String = "") {
-  #if DEBUG
+  #if canImport(Darwin)
     // https://github.com/bitstadium/HockeySDK-iOS/blob/c6e8d1e940299bec0c0585b1f7b86baf3b17fc82/Classes/BITHockeyHelper.m#L346-L370
     var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
     var info: kinfo_proc = kinfo_proc()
@@ -30,5 +32,7 @@ func breakpoint(_ message: @autoclosure () -> String = "") {
       )
       raise(SIGTRAP)
     }
+  #else
+    assertionFailure(message)
   #endif
 }

--- a/Sources/Parsing/Internal/Breakpoint.swift
+++ b/Sources/Parsing/Internal/Breakpoint.swift
@@ -1,0 +1,30 @@
+/// Raises a debug breakpoint if a debugger is attached.
+@inline(__always) func breakpoint(_ message: @autoclosure () -> String = "") {
+  #if DEBUG
+    // https://github.com/bitstadium/HockeySDK-iOS/blob/c6e8d1e940299bec0c0585b1f7b86baf3b17fc82/Classes/BITHockeyHelper.m#L346-L370
+    var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+    var info: kinfo_proc = kinfo_proc()
+    var info_size = MemoryLayout<kinfo_proc>.size
+
+    let isDebuggerAttached = name.withUnsafeMutableBytes {
+      $0.bindMemory(to: Int32.self).baseAddress
+        .map {
+          sysctl($0, 4, &info, &info_size, nil, 0) != -1 && info.kp_proc.p_flag & P_TRACED != 0
+        }
+        ?? false
+    }
+
+    if isDebuggerAttached {
+      fputs(
+        """
+        \(message())
+
+        Caught debug breakpoint. Type "continue" ("c") to resume execution.
+
+        """,
+        stderr
+      )
+      raise(SIGTRAP)
+    }
+  #endif
+}

--- a/Sources/Parsing/Parsers/Many.swift
+++ b/Sources/Parsing/Parsers/Many.swift
@@ -1,10 +1,4 @@
-#if canImport(Darwin)
-  import Darwin.C
-#elseif canImport(Glibc)
-  import Glibc
-#elseif canImport(WinSDK)
-  import WinSDK
-#endif
+import Foundation
 
 /// A parser that attempts to run another parser as many times as specified, accumulating the result
 /// of the outputs.

--- a/Sources/Parsing/Parsers/Many.swift
+++ b/Sources/Parsing/Parsers/Many.swift
@@ -107,7 +107,6 @@ where
           ---
           """
         )
-        break
       }
     }
     guard count >= self.minimum else {

--- a/Sources/Parsing/Parsers/Many.swift
+++ b/Sources/Parsing/Parsers/Many.swift
@@ -89,6 +89,14 @@ where
         break
       }
       if memcmp(&input, &previous, MemoryLayout<Upstream.Input>.size) == 0 {
+        breakpoint(
+          """
+          Many succeeded in parsing an \(Upstream.Output), but no input was consumed.
+
+          This is considered a logic error that would lead to an infinite loop, which should never \
+          happen.
+          """
+        )
         break
       }
     }

--- a/Sources/Parsing/Parsers/Many.swift
+++ b/Sources/Parsing/Parsers/Many.swift
@@ -2,6 +2,8 @@
   import Darwin.C
 #elseif canImport(Glibc)
   import Glibc
+#elseif canImport(WinSDK)
+  import WinSDK
 #endif
 
 /// A parser that attempts to run another parser as many times as specified, accumulating the result

--- a/Sources/Parsing/Parsers/Many.swift
+++ b/Sources/Parsing/Parsers/Many.swift
@@ -89,12 +89,22 @@ where
         break
       }
       if memcmp(&input, &previous, MemoryLayout<Upstream.Input>.size) == 0 {
+        var description = ""
+        debugPrint(output, terminator: "", to: &description)
         breakpoint(
           """
-          Many succeeded in parsing an \(Upstream.Output), but no input was consumed.
+          ---
+          A "Many" parser succeeded in parsing a value of "\(Upstream.Output.self)" \
+          (\(description)), but no input was consumed.
 
-          This is considered a logic error that would lead to an infinite loop, which should never \
-          happen.
+          This is considered a logic error that leads to an infinite loop, and is typically \
+          introduced by parsers that always succeed, even though they don't consume any input. \
+          This includes "Prefix" and "CharacterSet" parsers, which return an empty string when \
+          their predicate immediately fails.
+
+          To work around the problem, require that some input is consumed (for example, use \
+          "Prefix(minLength: 1)"), or introduce a "separator" parser to "Many".
+          ---
           """
         )
         break

--- a/Sources/Parsing/Parsers/Many.swift
+++ b/Sources/Parsing/Parsers/Many.swift
@@ -1,3 +1,9 @@
+#if canImport(Darwin)
+  import Darwin.C
+#elseif canImport(Glibc)
+  import Glibc
+#endif
+
 /// A parser that attempts to run another parser as many times as specified, accumulating the result
 /// of the outputs.
 ///
@@ -74,7 +80,11 @@ where
     var rest = input
     var result = self.initialResult
     var count = 0
-    while count < self.maximum, let output = self.upstream.parse(&input) {
+    while
+      count < self.maximum,
+      let output = self.upstream.parse(&input),
+      memcmp(&input, &rest, MemoryLayout<Upstream.Input>.size) != 0
+    {
       count += 1
       rest = input
       self.updateAccumulatingResult(&result, output)

--- a/Tests/ParsingTests/ManyTests.swift
+++ b/Tests/ParsingTests/ManyTests.swift
@@ -88,30 +88,6 @@ class ManyTests: XCTestCase {
     XCTAssertEqual(Substring(input), "")
   }
 
-  func testFailureIfNoProgress() {
-     var input = " Hello, World!"[...]
-     XCTAssertEqual(
-       Many(CharacterSet.alphanumerics).parse(&input),
-       [""]
-     )
-   }
-
-  func testSuccessThenNoProgress() {
-    var input = "Hello, World!"[...]
-    XCTAssertEqual(
-      Many(CharacterSet.alphanumerics).parse(&input),
-      ["Hello", ""]
-    )
-    XCTAssertEqual(Substring(input), ", World!")
-  }
-
-  func testArray() {
-    var input = [1, 2, 3, 4][...]
-    let output = Many(AnyParser { $0.first == 3 ? -3 : $0.removeFirst() }).parse(&input)
-    XCTAssertEqual([1, 2, -3], output)
-    XCTAssertEqual([3, 4], input)
-  }
-
   func testEmptyComponents() {
     var input = "2001:db8::2:1"[...]
     XCTAssertEqual(

--- a/Tests/ParsingTests/ManyTests.swift
+++ b/Tests/ParsingTests/ManyTests.swift
@@ -89,4 +89,21 @@ class ManyTests: XCTestCase {
     )
     XCTAssertEqual(Substring(input), "")
   }
+
+  func testFailureIfNoProgress() {
+     var input = " Hello, World!"[...]
+     XCTAssertEqual(
+       Many(CharacterSet.alphanumerics).parse(&input),
+       []
+     )
+   }
+
+   func testSuccessThenNoProgress() {
+     var input = "Hello, World!"[...]
+     XCTAssertEqual(
+       Many(CharacterSet.alphanumerics).parse(&input),
+       ["Hello"]
+     )
+     XCTAssertEqual(Substring(input), ", World!")
+   }
 }

--- a/Tests/ParsingTests/ManyTests.swift
+++ b/Tests/ParsingTests/ManyTests.swift
@@ -105,5 +105,18 @@ class ManyTests: XCTestCase {
        ["Hello"]
      )
      XCTAssertEqual(Substring(input), ", World!")
+
+     var xs = [1,2]
+     var ys = [1]
+     ys.append(contentsOf: [2])
+     XCTAssertEqual(memcmp(&xs, &ys, MemoryLayout<[Int]>.size), 0)
    }
+
+  func testEmptyComponents() {
+    var input = "2001:db8::2:1"[...]
+    XCTAssertEqual(
+      Many(Prefix(while: \.isHexDigit), separator: ":").parse(&input),
+      ["2001", "db8", "", "2", "1"]
+    )
+  }
 }

--- a/Tests/ParsingTests/ManyTests.swift
+++ b/Tests/ParsingTests/ManyTests.swift
@@ -4,10 +4,8 @@ import XCTest
 class ManyTests: XCTestCase {
   func testNoSeparator() {
     var input = "         Hello world"[...].utf8
-
     XCTAssertNotNil(
       Many(" ".utf8)
-        .orElse(Fail())
         .parse(&input)
     )
     XCTAssertEqual(Substring(input), "Hello world")
@@ -94,23 +92,25 @@ class ManyTests: XCTestCase {
      var input = " Hello, World!"[...]
      XCTAssertEqual(
        Many(CharacterSet.alphanumerics).parse(&input),
-       []
+       [""]
      )
    }
 
-   func testSuccessThenNoProgress() {
-     var input = "Hello, World!"[...]
-     XCTAssertEqual(
-       Many(CharacterSet.alphanumerics).parse(&input),
-       ["Hello"]
-     )
-     XCTAssertEqual(Substring(input), ", World!")
+  func testSuccessThenNoProgress() {
+    var input = "Hello, World!"[...]
+    XCTAssertEqual(
+      Many(CharacterSet.alphanumerics).parse(&input),
+      ["Hello", ""]
+    )
+    XCTAssertEqual(Substring(input), ", World!")
+  }
 
-     var xs = [1,2]
-     var ys = [1]
-     ys.append(contentsOf: [2])
-     XCTAssertEqual(memcmp(&xs, &ys, MemoryLayout<[Int]>.size), 0)
-   }
+  func testArray() {
+    var input = [1, 2, 3, 4][...]
+    let output = Many(AnyParser { $0.first == 3 ? -3 : $0.removeFirst() }).parse(&input)
+    XCTAssertEqual([1, 2, -3], output)
+    XCTAssertEqual([3, 4], input)
+  }
 
   func testEmptyComponents() {
     var input = "2001:db8::2:1"[...]


### PR DESCRIPTION
Just exploring an alternative implementation to #73.

Some unanswered questions:

- [ ] Can we come up with good examples of when we would _not_ want this behavior? _I.e._ what's a parser that could be fed to `Many`, not consume input, and succeed?
- [ ] Should this be a configuration option, as is done in #73?

@tgrapperon @iampatbrown Thoughts?