### PR TITLE
Add `NonEmpty` parser for parsers of `Collections`

### DIFF
--- a/Sources/Parsing/Parsers/NonEmpty.swift
+++ b/Sources/Parsing/Parsers/NonEmpty.swift
@@ -1,0 +1,35 @@
+extension Parser where Output: Collection {
+  /// Transforms the receiver parser of a `Collection` into one that fails when the output is empty.
+  @inlinable
+  public var nonEmpty: Parsers.NonEmpty<Self> {
+    .init(upstream: self)
+  }
+}
+
+extension Parsers {
+  /// A parser that fails when the output of another parser of a `Collection` type is empty.
+  ///
+  /// You will not typically need to interact with this type directly. Instead you will usually use
+  /// the ``Parser/nonEmpty`` operation, which constructs this type.
+  public struct NonEmpty<Upstream>: Parser where Upstream: Parser, Upstream.Output: Collection {
+    public let upstream: Upstream
+
+    @inlinable
+    public init(upstream: Upstream) {
+      self.upstream = upstream
+    }
+
+    @inlinable
+    public func parse(_ input: inout Upstream.Input) -> Upstream.Output? {
+      let original = input
+      guard let parsed = upstream.parse(&input) else {
+        return nil
+      }
+      if parsed.isEmpty {
+        input = original
+        return nil
+      }
+      return parsed
+    }
+  }
+}

--- a/Tests/ParsingTests/NonEmptyTests.swift
+++ b/Tests/ParsingTests/NonEmptyTests.swift
@@ -1,0 +1,16 @@
+import Parsing
+import XCTest
+
+final class NonEmptyTests: XCTestCase {
+  func testSuccess() {
+    var input = "Hello, world!"[...]
+    XCTAssertEqual("Hello", CharacterSet.alphanumerics.nonEmpty.parse(&input))
+    XCTAssertEqual(", world!", input)
+  }
+
+  func testFailure() {
+    var input = " Hello, world!"[...]
+    XCTAssertEqual(nil, CharacterSet.alphanumerics.nonEmpty.parse(&input))
+    XCTAssertEqual(" Hello, world!", input)
+  }
+}


### PR DESCRIPTION
This parser may be useful combined with the behaviors discussed in #73 and #74.