### PR TITLE
Clean up routing example

### DIFF
--- a/Sources/swift-parsing-benchmark/Routing.swift
+++ b/Sources/swift-parsing-benchmark/Routing.swift
@@ -9,7 +9,7 @@ import Parsing
  */
 
 let routingSuite = BenchmarkSuite(name: "Routing") { suite in
-  enum Route: Equatable {
+  enum AppRoute: Equatable {
     case home
     case contactUs
     case episodes
@@ -18,34 +18,34 @@ let routingSuite = BenchmarkSuite(name: "Routing") { suite in
   }
 
   let router = Method("GET")
-    .skip(End())
-    .map { Route.home }
+    .skip(PathEnd())
+    .map { AppRoute.home }
     .orElse(
       Method("GET")
         .skip(Path("contact-us".utf8))
-        .skip(End())
-        .map { Route.contactUs }
+        .skip(PathEnd())
+        .map { AppRoute.contactUs }
     )
     .orElse(
       Method("GET")
         .skip(Path("episodes".utf8))
-        .skip(End())
-        .map { Route.episodes }
+        .skip(PathEnd())
+        .map { AppRoute.episodes }
     )
     .orElse(
       Method("GET")
         .skip(Path("episodes".utf8))
         .take(Path(Int.parser()))
-        .skip(End())
-        .map(Route.episode(id:))
+        .skip(PathEnd())
+        .map(AppRoute.episode(id:))
     )
     .orElse(
       Method("GET")
         .skip(Path("episodes".utf8))
         .take(Path(Int.parser()))
         .skip(Path("comments".utf8))
-        .skip(End())
-        .map(Route.episodeComments(id:))
+        .skip(PathEnd())
+        .map(AppRoute.episodeComments(id:))
     )
 
   let requests = [
@@ -70,9 +70,9 @@ let routingSuite = BenchmarkSuite(name: "Routing") { suite in
     ),
   ]
 
-  var output: [Route]!
-  var expectedOutput = [
-    Route.home,
+  var output: [AppRoute]!
+  var expectedOutput: [AppRoute] = [
+    .home,
     .contactUs,
     .episodes,
     .episode(id: 1),
@@ -149,7 +149,7 @@ where
   }
 }
 
-private struct End: Parser {
+private struct PathEnd: Parser {
   typealias Input = RequestData
   typealias Output = Void
 


### PR DESCRIPTION
- `Route` is pretty generic, so let's use the more domain-specific `AppRoute`
- `End` is also pretty generic. We've preferred the more descriptive `PathEnd`