### PR TITLE
Cleanup: generic names, routing example

### DIFF
--- a/Sources/Parsing/Internal/Deprecations.swift
+++ b/Sources/Parsing/Internal/Deprecations.swift
@@ -1,3 +1,21 @@
+// NB: Deprecated after 0.4.0:
+
+extension Many {
+  @available(*, deprecated, renamed: "Element")
+  public typealias Upstream = Element
+
+  @available(*, deprecated, renamed: "element")
+  public var upstream: Upstream { self.element }
+}
+
+extension Parsers.OptionalParser {
+  @available(*, deprecated, renamed: "Wrapped")
+  public typealias Upstream = Wrapped
+
+  @available(*, deprecated, renamed: "element")
+  public var upstream: Upstream { self.wrapped }
+}
+
 // NB: Deprecated after 0.3.1:
 
 extension Parsers {

--- a/Sources/Parsing/Parsers/Many.swift
+++ b/Sources/Parsing/Parsers/Many.swift
@@ -29,49 +29,49 @@ import Foundation
 /// precondition(input == "")
 /// precondition(output == 6)
 /// ```
-public struct Many<Upstream, Result, Separator>: Parser
+public struct Many<Element, Result, Separator>: Parser
 where
-  Upstream: Parser,
+  Element: Parser,
   Separator: Parser,
-  Upstream.Input == Separator.Input
+  Element.Input == Separator.Input
 {
   public let initialResult: Result
   public let maximum: Int
   public let minimum: Int
   public let separator: Separator?
-  public let updateAccumulatingResult: (inout Result, Upstream.Output) -> Void
-  public let upstream: Upstream
+  public let updateAccumulatingResult: (inout Result, Element.Output) -> Void
+  public let element: Element
 
   /// Initializes a parser that attempts to run the given parser at least and at most the given
   /// number of times, accumulating the outputs into a result with a given closure.
   ///
   /// - Parameters:
-  ///   - upstream: Another parser.
+  ///   - element: A parser to run multiple times to accumulate into a result.
   ///   - minimum: The minimum number of times to run this parser and consider parsing to be
   ///     successful.
   ///   - maximum: The maximum number of times to run this parser before returning the output.
   ///   - separator: A parser that consumes input between each parsed output.
   ///   - updateAccumulatingResult: A closure that updates the accumulating result with each output
-  ///     of the upstream parser.
+  ///     of the element parser.
   @inlinable
   public init(
-    _ upstream: Upstream,
+    _ element: Element,
     into initialResult: Result,
     atLeast minimum: Int = 0,
     atMost maximum: Int = .max,
     separator: Separator,
-    _ updateAccumulatingResult: @escaping (inout Result, Upstream.Output) -> Void
+    _ updateAccumulatingResult: @escaping (inout Result, Element.Output) -> Void
   ) {
     self.initialResult = initialResult
     self.maximum = maximum
     self.minimum = minimum
     self.separator = separator
     self.updateAccumulatingResult = updateAccumulatingResult
-    self.upstream = upstream
+    self.element = element
   }
 
   @inlinable
-  public func parse(_ input: inout Upstream.Input) -> Result? {
+  public func parse(_ input: inout Element.Input) -> Result? {
     let original = input
     var rest = input
     #if DEBUG
@@ -80,7 +80,7 @@ where
     var result = self.initialResult
     var count = 0
     while count < self.maximum,
-      let output = self.upstream.parse(&input)
+      let output = self.element.parse(&input)
     {
       #if DEBUG
         defer { previous = input }
@@ -92,13 +92,13 @@ where
         break
       }
       #if DEBUG
-        if memcmp(&input, &previous, MemoryLayout<Upstream.Input>.size) == 0 {
+        if memcmp(&input, &previous, MemoryLayout<Element.Input>.size) == 0 {
           var description = ""
           debugPrint(output, terminator: "", to: &description)
           breakpoint(
             """
             ---
-            A "Many" parser succeeded in parsing a value of "\(Upstream.Output.self)" \
+            A "Many" parser succeeded in parsing a value of "\(Element.Output.self)" \
             (\(description)), but no input was consumed.
 
             This is considered a logic error that leads to an infinite loop, and is typically \
@@ -123,45 +123,45 @@ where
   }
 }
 
-extension Many where Result == [Upstream.Output], Separator == Always<Input, Void> {
+extension Many where Result == [Element.Output], Separator == Always<Input, Void> {
   /// Initializes a parser that attempts to run the given parser at least and at most the given
   /// number of times, accumulating the outputs in an array.
   ///
   /// - Parameters:
-  ///   - upstream: Another parser.
+  ///   - element: A parser to run multiple times to accumulate into an array.
   ///   - minimum: The minimum number of times to run this parser and consider parsing to be
   ///     successful.
   ///   - maximum: The maximum number of times to run this parser before returning the output.
   @inlinable
   public init(
-    _ upstream: Upstream,
+    _ element: Element,
     atLeast minimum: Int = 0,
     atMost maximum: Int = .max
   ) {
-    self.init(upstream, into: [], atLeast: minimum, atMost: maximum) {
+    self.init(element, into: [], atLeast: minimum, atMost: maximum) {
       $0.append($1)
     }
   }
 }
 
-extension Many where Result == [Upstream.Output] {
+extension Many where Result == [Element.Output] {
   /// Initializes a parser that attempts to run the given parser at least and at most the given
   /// number of times, accumulating the outputs in an array.
   ///
   /// - Parameters:
-  ///   - upstream: Another parser.
+  ///   - element: A parser to run multiple times to accumulate into an array.
   ///   - minimum: The minimum number of times to run this parser and consider parsing to be
   ///     successful.
   ///   - maximum: The maximum number of times to run this parser before returning the output.
   ///   - separator: A parser that consumes input between each parsed output.
   @inlinable
   public init(
-    _ upstream: Upstream,
+    _ element: Element,
     atLeast minimum: Int = 0,
     atMost maximum: Int = .max,
     separator: Separator
   ) {
-    self.init(upstream, into: [], atLeast: minimum, atMost: maximum, separator: separator) {
+    self.init(element, into: [], atLeast: minimum, atMost: maximum, separator: separator) {
       $0.append($1)
     }
   }
@@ -173,26 +173,26 @@ extension Many where Separator == Always<Input, Void> {
   /// number of times, accumulating the outputs into a result with a given closure.
   ///
   /// - Parameters:
-  ///   - upstream: Another parser.
+  ///   - element: A parser to run multiple times to accumulate into a result.
   ///   - minimum: The minimum number of times to run this parser and consider parsing to be
   ///     successful.
   ///   - maximum: The maximum number of times to run this parser before returning the output.
   ///   - updateAccumulatingResult: A closure that updates the accumulating result with each output
-  ///     of the upstream parser.
+  ///     of the element parser.
   @inlinable
   public init(
-    _ upstream: Upstream,
+    _ element: Element,
     into initialResult: Result,
     atLeast minimum: Int = 0,
     atMost maximum: Int = .max,
-    _ updateAccumulatingResult: @escaping (inout Result, Upstream.Output) -> Void
+    _ updateAccumulatingResult: @escaping (inout Result, Element.Output) -> Void
   ) {
     self.initialResult = initialResult
     self.maximum = maximum
     self.minimum = minimum
     self.separator = nil
     self.updateAccumulatingResult = updateAccumulatingResult
-    self.upstream = upstream
+    self.element = element
   }
 }
 

--- a/Sources/Parsing/Parsers/Optional.swift
+++ b/Sources/Parsing/Parsers/Optional.swift
@@ -13,21 +13,21 @@ extension Optional {
 }
 
 extension Parsers {
-  /// A parser that parses `nil` when its upstream parser fails.
+  /// A parser that parses `nil` when its wrapped parser fails.
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// `Optional.parser(of:)`, which constructs this type.
-  public struct OptionalParser<Upstream>: Parser where Upstream: Parser {
-    public let upstream: Upstream
+  public struct OptionalParser<Wrapped>: Parser where Wrapped: Parser {
+    public let wrapped: Wrapped
 
     @inlinable
-    public init(_ upstream: Upstream) {
-      self.upstream = upstream
+    public init(_ wrapped: Wrapped) {
+      self.wrapped = wrapped
     }
 
     @inlinable
-    public func parse(_ input: inout Upstream.Input) -> Upstream.Output?? {
-      .some(self.upstream.parse(&input))
+    public func parse(_ input: inout Wrapped.Input) -> Wrapped.Output?? {
+      .some(self.wrapped.parse(&input))
     }
   }
 }

--- a/Sources/swift-parsing-benchmark/Routing.swift
+++ b/Sources/swift-parsing-benchmark/Routing.swift
@@ -154,13 +154,7 @@ private struct PathEnd: Parser {
   typealias Output = Void
 
   func parse(_ input: inout Input) -> Output? {
-    guard
-      input.method == nil,
-      input.pathComponents.isEmpty
-    else { return nil }
-
-    input = .init()
-
+    guard input.pathComponents.isEmpty else { return nil }
     return ()
   }
 }


### PR DESCRIPTION
A couple things I noticed.

- While `Upstream` works well in some contexts, in others I think we can be more specific.
- `PathEnd` in the routing example should probably _only_ check the path.