### PR TITLE
`Int.parser` Fixes

### DIFF
--- a/Sources/Parsing/Parsers/Int.swift
+++ b/Sources/Parsing/Parsers/Int.swift
@@ -20,7 +20,7 @@ extension FixedWidthInteger {
   public static func parser<Input>(
     of inputType: Input.Type = Input.self,
     isSigned: Bool = true,
-    radix: Self = 10
+    radix: Int = 10
   ) -> Parsers.IntParser<Input, Self> {
     .init(isSigned: isSigned, radix: radix)
   }
@@ -40,11 +40,11 @@ extension FixedWidthInteger {
   /// - Returns: A parser that consumes an integer from the beginning of a substring's UTF-8 view.
   @_disfavoredOverload
   @inlinable
-  public static func parser<Input>(
+  public static func parser(
     of inputType: Substring.UTF8View.Type = Substring.UTF8View.self,
     isSigned: Bool = true,
-    radix: Self = 10
-  ) -> Parsers.IntParser<Input, Self> {
+    radix: Int = 10
+  ) -> Parsers.IntParser<Substring.UTF8View, Self> {
     .init(isSigned: isSigned, radix: radix)
   }
 
@@ -65,7 +65,7 @@ extension FixedWidthInteger {
   public static func parser(
     of inputType: Substring.Type = Substring.self,
     isSigned: Bool = true,
-    radix: Self = 10
+    radix: Int = 10
   ) -> Parsers.UTF8ViewToSubstring<Parsers.IntParser<Substring.UTF8View, Self>> {
     .init(.init(isSigned: isSigned, radix: radix))
   }
@@ -88,10 +88,10 @@ extension Parsers {
     public let isSigned: Bool
 
     /// The radix, or base, to use for converting text to an integer value.
-    public let radix: Output
+    public let radix: Int
 
     @inlinable
-    public init(isSigned: Bool = true, radix: Output = 10) {
+    public init(isSigned: Bool = true, radix: Int = 10) {
       precondition((2...36).contains(radix), "Radix not in range 2...36")
       self.isSigned = isSigned
       self.radix = radix
@@ -137,8 +137,9 @@ extension Parsers {
         output = n
       }
       length += 1
+      let radix = Output(self.radix)
       while let next = iterator.next(), let n = digit(for: next) {
-        (output, overflow) = output.multipliedReportingOverflow(by: self.radix)
+        (output, overflow) = output.multipliedReportingOverflow(by: radix)
         guard !overflow else { return nil }
         (output, overflow) =
           isPositive


### PR DESCRIPTION
A couple small discoveries while going over various materials.

1. We have an erroneous version of `Int.parser` takes an explicit input type and ignores it.
2. We use `Radix: Self` in `Int.parser`, which means `Radix` would be `UInt8` for `UInt8.parser`, but `UInt8.init(_:radix:)` and the others use `Int` for the radix parameter, so let's clean this up.