### PR TITLE
Add character set parser tests

### DIFF
--- a/Tests/ParsingTests/CharacterSetTests.swift
+++ b/Tests/ParsingTests/CharacterSetTests.swift
@@ -1,0 +1,46 @@
+import Parsing
+import XCTest
+
+final class CharacterSetTests: XCTestCase {
+    func testDecimalDigits() {
+        let characterSet = CharacterSet.decimalDigits
+
+        var input = "42abc"[...]
+
+        let output = characterSet.parse(&input)
+        XCTAssertEqual(output, "42")
+        XCTAssertEqual(input, "abc")
+    }
+
+    func testAlphanumerics() {
+        let characterSet = CharacterSet.alphanumerics
+
+        var input = "42abc;."[...]
+
+        let output = characterSet.parse(&input)
+        XCTAssertEqual(output, "42abc")
+        XCTAssertEqual(input, ";.")
+    }
+
+    func testCustom() {
+        let characterSet = CharacterSet(charactersIn: "0123")
+
+        var input = "23456789abcdef"[...]
+
+        let output = characterSet.parse(&input)
+        XCTAssertEqual(output, "23")
+        XCTAssertEqual(input, "456789abcdef")
+    }
+
+    func testCompletion() throws {
+        let characterSet = CharacterSet(charactersIn: "123")
+
+        var input = "123456"[...]
+
+        let firstOutput = try XCTUnwrap(characterSet.parse(&input))
+        let secondOutput = try XCTUnwrap(characterSet.parse(&input))
+
+        XCTAssertEqual(firstOutput, "123")
+        XCTAssertTrue(secondOutput.isEmpty)
+    }
+}


### PR DESCRIPTION
- <s>Return nil when character set parser has no output</s>
- Add character set parsing tests

The rest of the test suite passes as well.

<s>Based on the [documentation](https://pointfreeco.github.io/swift-parsing/Parser/), my understanding is that a `CharacterSet`-based parser needs to return `nil` when the first character of its input isn't a member of the character set. </s>

I think there might be edge cases with non-ASCII characters that might be worth adding to tests, which I'm happy to do. Added some basic `CharacterSet` tests and tests for this specific change as a starter.