### PR TITLE
Use a `ResultBuilder` of `String` in VariadicGenerator

### DIFF
--- a/Sources/variadics-generator/StringBuilder.swift
+++ b/Sources/variadics-generator/StringBuilder.swift
@@ -1,0 +1,39 @@
+@resultBuilder
+enum StringBuilder {
+  typealias Expression = String
+  typealias Component = [String]
+
+  static func buildExpression(_ expression: Expression) -> Component {
+    [expression]
+  }
+  static func buildBlock(_ components: Component...) -> Component {
+    components.flatMap { $0 }
+  }
+  static func buildArray(_ components: [Component]) -> Component {
+    components.flatMap { $0 }
+  }
+  static func buildOptional(_ component: Component?) -> Component {
+    component ?? []
+  }
+  static func buildEither(first component: Component) -> Component {
+    component
+  }
+  static func buildEither(second component: Component) -> Component {
+    component
+  }
+  static func buildLimitedAvailability(_ component: Component) -> Component {
+    component
+  }
+  static func buildFinalResult(_ component: Component) -> String {
+    component.joined(separator: "\n")
+  }
+}
+
+extension String {
+  // Using String.init is a little too much for the compiler.
+  static func build(
+    @StringBuilder lines: () -> String
+  ) -> String {
+    lines()
+  }
+}

--- a/Sources/variadics-generator/StringBuilder.swift
+++ b/Sources/variadics-generator/StringBuilder.swift
@@ -30,7 +30,7 @@ enum StringBuilder {
 }
 
 extension String {
-  // Using String.init is a little too much for the compiler.
+  // Overloading String.init is a little too much for the compiler.
   static func build(
     @StringBuilder lines: () -> String
   ) -> String {

--- a/Sources/variadics-generator/VariadicsGenerator.swift
+++ b/Sources/variadics-generator/VariadicsGenerator.swift
@@ -125,7 +125,9 @@ struct VariadicsGenerator: ParsableCommand {
           "    }"
           ""
           "    @inlinable public func parse(_ input: inout P0.Input) -> ("
-          list(permutation.captureIndices, separator: ",\n") { "      P\($0).Output" }
+          list(permutation.captureIndices, separator: ",\n") {
+            "      P\($0).Output"
+          }
           "    )? {"
           "      guard "
           list(0..<arity, separator: ",\n") {

--- a/Sources/variadics-generator/VariadicsGenerator.swift
+++ b/Sources/variadics-generator/VariadicsGenerator.swift
@@ -99,7 +99,7 @@ struct VariadicsGenerator: ParsableCommand {
         String.build {
           // Emit type declarations.
           "extension Parsers {"
-          "  public struct \(typeName)<\(list(0..<arity){ "P\($0)" })>: Parser"
+          "  public struct \(typeName)<" + list(0..<arity){ "P\($0)" } + ">: Parser"
           "  where"
           for i in 0..<arity {
             "    P\(i): Parser,"
@@ -118,7 +118,7 @@ struct VariadicsGenerator: ParsableCommand {
           "  {"
           "    public let " + list(0..<arity) { "p\($0): P\($0)" }
           ""
-          "    @inlinable public init(\(list(0..<arity) { "_ p\($0): P\($0)"})) {"
+          "    @inlinable public init(" + list(0..<arity) { "_ p\($0): P\($0)" } + ") {"
           for i in 0..<arity {
             "      self.p\(i) = p\(i)"
           }
@@ -136,17 +136,17 @@ struct VariadicsGenerator: ParsableCommand {
           "      else {"
           "        return nil"
           "      }"
-          "      return (\(list(permutation.captureIndices){"o\($0)"}))"
+          "      return (" + list(permutation.captureIndices){ "o\($0)" } + ")"
           "    }"
           "  }"
           "}"
           ""
           // Emit builders.
           "extension ParserBuilder {"
-          "  @inlinable public static func buildBlock<\(list(0..<arity){ "P\($0)" })>("
+          "  @inlinable public static func buildBlock<" + list(0..<arity){ "P\($0)" } + ">("
           "    " + list(0..<arity) { "_ p\($0): P\($0)" }
-          "  ) -> Parsers.\(typeName)<\(list(0..<arity){ "P\($0)" })> {"
-          "    Parsers.\(typeName)(\(list(0..<arity){ "p\($0)" }))"
+          "  ) -> Parsers.\(typeName)<" + list(0..<arity){ "P\($0)" } + "> {"
+          "    Parsers.\(typeName)(" + list(0..<arity){ "p\($0)" } + ")"
           "  }"
           "}"
           ""
@@ -160,7 +160,7 @@ struct VariadicsGenerator: ParsableCommand {
     output.append(
       String.build {
         // Emit type declarations.
-        "extension Parsers {\n  public struct \(typeName)<\(list(0..<arity, { "P\($0)" }))>: Parser"
+        "extension Parsers {\n  public struct \(typeName)<" + list(0..<arity) { "P\($0)" } + ">: Parser"
         "  where"
         for i in 0..<arity {
           "    P\(i): Parser,"
@@ -195,10 +195,10 @@ struct VariadicsGenerator: ParsableCommand {
         ""
         // Emit type declarations.
         "extension OneOfBuilder {"
-        "  @inlinable public static func buildBlock<\(list(0..<arity){ "P\($0)" })>("
+        "  @inlinable public static func buildBlock<" + list(0..<arity){ "P\($0)" } + ">("
         "    " + list(0..<arity) { "_ p\($0): P\($0)" }
-        "  ) -> Parsers.\(typeName)<\(list(0..<arity){ "P\($0)" })> {"
-        "    Parsers.\(typeName)(\(list(0..<arity){ "p\($0)" }))"
+        "  ) -> Parsers.\(typeName)<" + list(0..<arity){ "P\($0)" } + "> {"
+        "    Parsers.\(typeName)(" + list(0..<arity){ "p\($0)" } + ")"
         "  }"
         "}"
         ""

--- a/Sources/variadics-generator/VariadicsGenerator.swift
+++ b/Sources/variadics-generator/VariadicsGenerator.swift
@@ -64,12 +64,12 @@ struct Permutations: Sequence {
   }
 }
 
-func list<C>(
-  _ sequence: C,
+func list<S>(
+  _ sequence: S,
   separator: String = ", ",
   terminator: String = "",
-  @StringBuilder _ component: @escaping (C.Element) -> String
-) -> String where C: Sequence {
+  @StringBuilder _ component: @escaping (S.Element) -> String
+) -> String where S: Sequence {
   sequence.map(component).joined(separator: separator) + terminator
 }
 

--- a/Sources/variadics-generator/VariadicsGenerator.swift
+++ b/Sources/variadics-generator/VariadicsGenerator.swift
@@ -91,21 +91,21 @@ struct VariadicsGenerator: ParsableCommand {
     print(output.joined(separator: "\n"))
   }
 
-  func emitZipDeclarations(arity: Int) {
-    for permutation in Permutations(arity: arity) {
+  func emitZipDeclarations(arity n: Int) {
+    for permutation in Permutations(arity: n) {
       let typeName = "Zip\(permutation.identifier)"
 
       output.append(
         String.build {
           // Emit type declarations.
           "extension Parsers {"
-          "  public struct \(typeName)<" + list(0..<arity){ "P\($0)" } + ">: Parser"
+          "  public struct \(typeName)<" + list(0..<n) { "P\($0)" } + ">: Parser"
           "  where"
-          for i in 0..<arity {
+          for i in 0..<n {
             "    P\(i): Parser,"
           }
           list(
-            zip(0..<arity, (0..<arity).dropFirst()), separator: ",\n",
+            zip(0..<n, (0..<n).dropFirst()), separator: ",\n",
             terminator: permutation.hasCaptureless ? "," : ""
           ) {
             "    P\($0).Input == P\($1).Input"
@@ -116,10 +116,10 @@ struct VariadicsGenerator: ParsableCommand {
             }
           }
           "  {"
-          "    public let " + list(0..<arity) { "p\($0): P\($0)" }
+          "    public let " + list(0..<n) { "p\($0): P\($0)" }
           ""
-          "    @inlinable public init(" + list(0..<arity) { "_ p\($0): P\($0)" } + ") {"
-          for i in 0..<arity {
+          "    @inlinable public init(" + list(0..<n) { "_ p\($0): P\($0)" } + ") {"
+          for i in 0..<n {
             "      self.p\(i) = p\(i)"
           }
           "    }"
@@ -130,7 +130,7 @@ struct VariadicsGenerator: ParsableCommand {
           }
           "    )? {"
           "      guard "
-          list(0..<arity, separator: ",\n") {
+          list(0..<n, separator: ",\n") {
             "        let \(permutation.isCaptureless(at: $0) ? "_" : "o\($0)") = p\($0).parse(&input)"
           }
           "      else {"
@@ -143,10 +143,10 @@ struct VariadicsGenerator: ParsableCommand {
           ""
           // Emit builders.
           "extension ParserBuilder {"
-          "  @inlinable public static func buildBlock<" + list(0..<arity){ "P\($0)" } + ">("
-          "    " + list(0..<arity) { "_ p\($0): P\($0)" }
-          "  ) -> Parsers.\(typeName)<" + list(0..<arity){ "P\($0)" } + "> {"
-          "    Parsers.\(typeName)(" + list(0..<arity){ "p\($0)" } + ")"
+          "  @inlinable public static func buildBlock<" + list(0..<n) { "P\($0)" } + ">("
+          "    " + list(0..<n) { "_ p\($0): P\($0)" }
+          "  ) -> Parsers.\(typeName)<" + list(0..<n) { "P\($0)" } + "> {"
+          "    Parsers.\(typeName)(" + list(0..<n) { "p\($0)" } + ")"
           "  }"
           "}"
           ""
@@ -155,33 +155,33 @@ struct VariadicsGenerator: ParsableCommand {
     }
   }
 
-  func emitOneOfDeclaration(arity: Int) {
-    let typeName = "OneOf\(arity)"
+  func emitOneOfDeclaration(arity n: Int) {
+    let typeName = "OneOf\(n)"
     output.append(
       String.build {
         // Emit type declarations.
-        "extension Parsers {\n  public struct \(typeName)<" + list(0..<arity) { "P\($0)" } + ">: Parser"
+        "extension Parsers {\n  public struct \(typeName)<" + list(0..<n) { "P\($0)" } + ">: Parser"
         "  where"
-        for i in 0..<arity {
+        for i in 0..<n {
           "    P\(i): Parser,"
         }
-        for (i, j) in zip(0..<arity, (0..<arity).dropFirst()) {
+        for (i, j) in zip(0..<n, (0..<n).dropFirst()) {
           "    P\(i).Input == P\(j).Input,"
         }
-        list(zip(0..<arity, (0..<arity).dropFirst()), separator: ",\n") {
+        list(zip(0..<n, (0..<n).dropFirst()), separator: ",\n") {
           "    P\($0).Output == P\($1).Output"
         }
         "  {"
-        "    public let " + list(0..<arity) { "p\($0): P\($0)" }
+        "    public let " + list(0..<n) { "p\($0): P\($0)" }
         ""
-        "    @inlinable public init(" + list(0..<arity) { "_ p\($0): P\($0)" } + ") {"
-        for i in 0..<arity {
+        "    @inlinable public init(" + list(0..<n) { "_ p\($0): P\($0)" } + ") {"
+        for i in 0..<n {
           "      self.p\(i) = p\(i)"
         }
         "    }"
         ""
         "    @inlinable public func parse(_ input: inout P0.Input) -> P0.Output? {"
-        for i in 0..<arity {
+        for i in 0..<n {
           "      var i\(i) = input"
           "      if let output = self.p\(i).parse(&i\(i)) {"
           "        input = i\(i)"
@@ -195,10 +195,10 @@ struct VariadicsGenerator: ParsableCommand {
         ""
         // Emit type declarations.
         "extension OneOfBuilder {"
-        "  @inlinable public static func buildBlock<" + list(0..<arity){ "P\($0)" } + ">("
-        "    " + list(0..<arity) { "_ p\($0): P\($0)" }
-        "  ) -> Parsers.\(typeName)<" + list(0..<arity){ "P\($0)" } + "> {"
-        "    Parsers.\(typeName)(" + list(0..<arity){ "p\($0)" } + ")"
+        "  @inlinable public static func buildBlock<" + list(0..<n) { "P\($0)" } + ">("
+        "    " + list(0..<n) { "_ p\($0): P\($0)" }
+        "  ) -> Parsers.\(typeName)<" + list(0..<n) { "P\($0)" } + "> {"
+        "    Parsers.\(typeName)(" + list(0..<n) { "p\($0)" } + ")"
         "  }"
         "}"
         ""


### PR DESCRIPTION
It is very possible that more intricate codegen will be needed in the future, and I feel this `@StringBuilder` that builds `String`'s lines by lines is already helping making things a little clearer.

For example:
```swift
output("extension OneOfBuilder {\n")
output("  @inlinable public static func buildBlock<")
outputForEach(0..<arity, separator: ", ") { "P\($0)" }
output(">(\n    ")
outputForEach(0..<arity, separator: ", ") { "_ p\($0): P\($0)" }
output("\n  ) -> Parsers.\(typeName)<")
outputForEach(0..<arity, separator: ", ") { "P\($0)" }
output("> {\n")
output("    Parsers.\(typeName)(")
outputForEach(0..<arity, separator: ", ") { "p\($0)" }
output(")\n  }\n}\n\n")
```
becomes:
```swift
"extension OneOfBuilder {"
"  @inlinable public static func buildBlock<\(list(0..<arity){ "P\($0)" })>("
"    " + list(0..<arity) { "_ p\($0): P\($0)" }
"  ) -> Parsers.\(typeName)<\(list(0..<arity){ "P\($0)" })> {"
"    Parsers.\(typeName)(\(list(0..<arity){ "p\($0)" }))"
"  }"
"}"
```

I'm using `for xx in` when no separator is needed, but it can feel a little weird when intertwined with the `list` function that works like `outputForEach ` (but with `", "` as default separator). Maybe some specific `forEach` function can be introduced to replace some `for in` loops with a syntax that is closer to `list`. Please let me know if there's some interest and I'll add one to the PR.

The code generated is the same as the current version of `Variadics.swift`, modulo some line wraps from `swift-format` with the latest `OneOfBuilder`'s.