### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ let user = Parse {
 Already this can consume the beginning of the input:
 
 ```swift
-// Use a mutable substring to verify what it consumed
+// Use a mutable substring to verify what is consumed
 var input = input[...]
 
 user.parse(&input) // => 1

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ let user = Parse {
 Already this can consume the beginning of the input:
 
 ```swift
+// Use a mutable substring to verify what it consumed
+var input = input[...]
+
 user.parse(&input) // => 1
 input // => "Blob,true\n2,Blob Jr.,false\n3,Blob Sr.,true"
 ```


### PR DESCRIPTION
While we show the `[...]` subscripting later in the README and pretty often in our docs, we miss the first one here.