### PR TITLE
Remove extra `configs:`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,9 +3,7 @@ builder:
   configs:
   - platform: ios
     scheme: Parsing
-  configs:
   - platform: tvos
     scheme: Parsing
-  configs:
   - platform: watchos
     scheme: Parsing_watchOS


### PR DESCRIPTION
See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1541

Because of the three `configs:` sections we're only getting the `watchos` section when reading the `.spi.yml` file. That's why iOS and tvOS are failing :)