### PR TITLE
coalesce manyFailed error messages

### DIFF
--- a/Tests/ParsingTests/ManyTests.swift
+++ b/Tests/ParsingTests/ManyTests.swift
@@ -197,16 +197,10 @@ class ManyTests: XCTestCase {
     XCTAssertThrowsError(try intsParser.parse(&input)) { error in
       XCTAssertEqual(
         """
-        error: multiple failures occurred
-
         error: unexpected input
          --> input:1:6
         1 | 1,2,3-
           |      ^ expected ","
-
-        error: unexpected input
-         --> input:1:6
-        1 | 1,2,3-
           |      ^ expected "---"
         """,
         "\(error)"

--- a/Tests/ParsingTests/OneOfBuilderTests.swift
+++ b/Tests/ParsingTests/OneOfBuilderTests.swift
@@ -21,21 +21,11 @@ final class OneOfBuilderTests: XCTestCase {
     XCTAssertThrowsError(try parser.parse("president")) { error in
       XCTAssertEqual(
         """
-        error: multiple failures occurred
-
         error: unexpected input
          --> input:1:1
         1 | president
           | ^ expected "admin"
-
-        error: unexpected input
-         --> input:1:1
-        1 | president
           | ^ expected "guest"
-
-        error: unexpected input
-         --> input:1:1
-        1 | president
           | ^ expected "member"
         """,
         "\(error)"
@@ -64,16 +54,10 @@ final class OneOfBuilderTests: XCTestCase {
     XCTAssertThrowsError(try parser.parse("admin")) { error in
       XCTAssertEqual(
         """
-        error: multiple failures occurred
-
         error: unexpected input
          --> input:1:1
         1 | admin
           | ^ expected "guest"
-
-        error: unexpected input
-         --> input:1:1
-        1 | admin
           | ^ expected "member"
         """,
         "\(error)"
@@ -94,21 +78,11 @@ final class OneOfBuilderTests: XCTestCase {
     XCTAssertThrowsError(try parser.parse("president")) { error in
       XCTAssertEqual(
         """
-        error: multiple failures occurred
-
         error: unexpected input
          --> input:1:1
         1 | president
           | ^ expected "admin"
-
-        error: unexpected input
-         --> input:1:1
-        1 | president
           | ^ expected "guest"
-
-        error: unexpected input
-         --> input:1:1
-        1 | president
           | ^ expected "member"
         """,
         "\(error)"

--- a/Tests/ParsingTests/OneOfTests.swift
+++ b/Tests/ParsingTests/OneOfTests.swift
@@ -163,4 +163,188 @@ final class OneOfTests: XCTestCase {
       )
     }
   }
+
+  func testJSON() {
+    enum JSONValue: Equatable {
+      case array([Self])
+      case boolean(Bool)
+      case null
+      case number(Double)
+      case object([String: Self])
+      case string(String)
+    }
+
+    var json: AnyParser<Substring.UTF8View, JSONValue>!
+
+    let unicode = Prefix(4) {
+      (.init(ascii: "0") ... .init(ascii: "9")).contains($0)
+      || (.init(ascii: "A") ... .init(ascii: "F")).contains($0)
+      || (.init(ascii: "a") ... .init(ascii: "f")).contains($0)
+    }
+      .compactMap {
+        UInt32(Substring($0), radix: 16)
+          .flatMap(UnicodeScalar.init)
+          .map(String.init)
+      }
+
+    let string = Parse {
+      "\"".utf8
+      Many(into: "") { string, fragment in
+        string.append(contentsOf: fragment)
+      } element: {
+        OneOf {
+          Prefix(1...) { $0 != .init(ascii: "\"") && $0 != .init(ascii: "\\") }
+          .map { String(Substring($0)) }
+
+          Parse {
+            "\\".utf8
+
+            OneOf {
+              "\"".utf8.map { "\"" }
+              "\\".utf8.map { "\\" }
+              "/".utf8.map { "/" }
+              "b".utf8.map { "\u{8}" }
+              "f".utf8.map { "\u{c}" }
+              "n".utf8.map { "\n" }
+              "r".utf8.map { "\r" }
+              "t".utf8.map { "\t" }
+              unicode
+            }
+          }
+        }
+      } terminator: {
+        "\"".utf8
+      }
+    }
+
+    let object = Parse {
+      "{".utf8
+      Many(into: [String: JSONValue]()) { object, pair in
+        let (name, value) = pair
+        object[name] = value
+      } element: {
+        Skip { Whitespace() }
+        string
+        Skip { Whitespace() }
+        ":".utf8
+        Lazy { json! }
+      } separator: {
+        ",".utf8
+      } terminator: {
+        "}".utf8
+      }
+    }
+
+    let array = Parse {
+      "[".utf8
+      Many {
+        Lazy { json! }
+      } separator: {
+        ",".utf8
+      } terminator: {
+        "]".utf8
+      }
+    }
+
+    json = Parse {
+      Skip { Whitespace() }
+      OneOf {
+        object.map(JSONValue.object)
+        array.map(JSONValue.array)
+        string.map(JSONValue.string)
+        Double.parser().map(JSONValue.number)
+        Bool.parser().map(JSONValue.boolean)
+        "null".utf8.map { JSONValue.null }
+      }
+      Skip { Whitespace() }
+    }
+    .eraseToAnyParser()
+
+    let input = #"""
+      {
+        "hello": true,
+        "goodbye": 42.42,
+        "whatever": null,
+        "xs": [1, "hello, null, false],
+        "ys": {
+          "0": 2,
+          "1": "goodbye"
+        }
+      }
+      """#
+
+    XCTAssertThrowsError(try json.parse(input)) { error in
+      XCTAssertEqual(
+        #"""
+        error: multiple failures occurred
+
+        error: unexpected input
+         --> input:6:4
+        6 |   "ys": {
+          |    ^ expected ","
+
+        error: unexpected input
+         --> input:6:4
+        6 |   "ys": {
+          |    ^ expected "]"
+
+        error: unexpected input
+         --> input:5:9
+        5 |   "xs": [1, "hello, null, false],
+          |         ^ expected "{"
+
+        error: unexpected input
+         --> input:5:9
+        5 |   "xs": [1, "hello, null, false],
+          |         ^ expected "\""
+
+        error: unexpected input
+         --> input:5:9
+        5 |   "xs": [1, "hello, null, false],
+          |         ^ expected double
+
+        error: unexpected input
+         --> input:5:9
+        5 |   "xs": [1, "hello, null, false],
+          |         ^ expected "true" or "false"
+
+        error: unexpected input
+         --> input:5:9
+        5 |   "xs": [1, "hello, null, false],
+          |         ^ expected "null"
+
+        error: unexpected input
+         --> input:4:19
+        4 |   "whatever": null,
+          |                   ^ expected "}"
+
+        error: unexpected input
+         --> input:1:1
+        1 | {
+          | ^ expected "["
+
+        error: unexpected input
+         --> input:1:1
+        1 | {
+          | ^ expected "\""
+
+        error: unexpected input
+         --> input:1:1
+        1 | {
+          | ^ expected double
+
+        error: unexpected input
+         --> input:1:1
+        1 | {
+          | ^ expected "true" or "false"
+
+        error: unexpected input
+         --> input:1:1
+        1 | {
+          | ^ expected "null"
+        """#,
+        "\(error)"
+      )
+    }
+  }
 }

--- a/Tests/ParsingTests/OneOfTests.swift
+++ b/Tests/ParsingTests/OneOfTests.swift
@@ -37,16 +37,10 @@ final class OneOfTests: XCTestCase {
     ) { error in
       XCTAssertEqual(
         """
-        error: multiple failures occurred
-
         error: unexpected input
          --> input:1:1
         1 | London, Hello!
           | ^ expected "New York"
-
-        error: unexpected input
-         --> input:1:1
-        1 | London, Hello!
           | ^ expected "Berlin"
         """,
         "\(error)"
@@ -92,16 +86,10 @@ final class OneOfTests: XCTestCase {
     ) { error in
       XCTAssertEqual(
         """
-        error: multiple failures occurred
-
         error: unexpected input
          --> input:1:1
         1 | London, Hello!
           | ^ expected "New York"
-
-        error: unexpected input
-         --> input:1:1
-        1 | London, Hello!
           | ^ expected "Berlin"
         """,
         "\(error)"
@@ -282,35 +270,15 @@ final class OneOfTests: XCTestCase {
          --> input:6:4
         6 |   "ys": {
           |    ^ expected ","
-
-        error: unexpected input
-         --> input:6:4
-        6 |   "ys": {
           |    ^ expected "]"
 
         error: unexpected input
          --> input:5:9
         5 |   "xs": [1, "hello, null, false],
           |         ^ expected "{"
-
-        error: unexpected input
-         --> input:5:9
-        5 |   "xs": [1, "hello, null, false],
           |         ^ expected "\""
-
-        error: unexpected input
-         --> input:5:9
-        5 |   "xs": [1, "hello, null, false],
           |         ^ expected double
-
-        error: unexpected input
-         --> input:5:9
-        5 |   "xs": [1, "hello, null, false],
           |         ^ expected "true" or "false"
-
-        error: unexpected input
-         --> input:5:9
-        5 |   "xs": [1, "hello, null, false],
           |         ^ expected "null"
 
         error: unexpected input
@@ -322,25 +290,9 @@ final class OneOfTests: XCTestCase {
          --> input:1:1
         1 | {
           | ^ expected "["
-
-        error: unexpected input
-         --> input:1:1
-        1 | {
           | ^ expected "\""
-
-        error: unexpected input
-         --> input:1:1
-        1 | {
           | ^ expected double
-
-        error: unexpected input
-         --> input:1:1
-        1 | {
           | ^ expected "true" or "false"
-
-        error: unexpected input
-         --> input:1:1
-        1 | {
           | ^ expected "null"
         """#,
         "\(error)"


### PR DESCRIPTION
In `ParsingError.debugDescription`, check for a `manyFailed` where all
the child errors are `ParsingError.failure` with the same
`originalInput` and `remainingInput` and no `underlyingError`s. In such
a scenario, only output the context once, for a more compact and legible
diagnostic.

Before:

    error: multiple failures occurred

    error: unexpected input
     --> input:1:1
    1 | president
      | ^ expected "admin"

    error: unexpected input
     --> input:1:1
    1 | president
      | ^ expected "guest"

    error: unexpected input
     --> input:1:1
    1 | president
      | ^ expected "member"

After:

    error: unexpected input
     --> input:1:1
    1 | president
      | ^ expected "admin"
      | ^ expected "guest"
      | ^ expected "member"