### PR TITLE
Prefix should eagerly consume

### DIFF
--- a/Sources/Parsing/Parsers/Prefix.swift
+++ b/Sources/Parsing/Parsers/Prefix.swift
@@ -170,6 +170,7 @@ public struct Prefix<Input: Collection>: Parser where Input.SubSequence == Input
     var prefix = maxLength.map(input.prefix) ?? input
     prefix = predicate.map { prefix.prefix(while: $0) } ?? prefix
     let count = prefix.count
+    input.removeFirst(count)
     guard count >= self.minLength else {
       let atLeast = self.minLength - count
       throw ParsingError.expectedInput(
@@ -177,10 +178,9 @@ public struct Prefix<Input: Collection>: Parser where Input.SubSequence == Input
         \(self.minLength - count) \(count == 0 ? "" : "more ")element\(atLeast == 1 ? "" : "s")\
         \(predicate == nil ? "" : " satisfying predicate")
         """,
-        at: input.dropFirst(self.minLength)
+        at: input
       )
     }
-    input.removeFirst(count)
     return prefix
   }
 }

--- a/Sources/swift-parsing-benchmark/JSON.swift
+++ b/Sources/swift-parsing-benchmark/JSON.swift
@@ -35,8 +35,10 @@ let jsonSuite = BenchmarkSuite(name: "JSON") { suite in
       string.append(contentsOf: fragment)
     } element: {
       OneOf {
-        Prefix(1...) { $0 != .init(ascii: "\"") && $0 != .init(ascii: "\\") }
-          .map { String(Substring($0)) }
+        Prefix(1...) {
+          $0 != .init(ascii: "\"") && $0 != .init(ascii: "\\") && $0 >= .init(ascii: " ")
+        }
+        .map { String(Substring($0)) }
 
         Parse {
           "\\".utf8

--- a/Tests/ParsingTests/ParsingErrorTests.swift
+++ b/Tests/ParsingTests/ParsingErrorTests.swift
@@ -98,7 +98,7 @@ class ParsingErrorTests: XCTestCase {
     }
   }
 
-  func testEOLContext() {
+  func testComplexStringLiteralParserError() {
     let stringLiteral = Parse {
       "\""
       Many(into: "") {

--- a/Tests/ParsingTests/ParsingErrorTests.swift
+++ b/Tests/ParsingTests/ParsingErrorTests.swift
@@ -97,4 +97,58 @@ class ParsingErrorTests: XCTestCase {
       )
     }
   }
+
+  func testEOLContext() {
+    let stringLiteral = Parse {
+      "\""
+      Many(into: "") {
+        $0.append(contentsOf: $1)
+      } element: {
+        OneOf {
+          Prefix(1...) { $0 != "\"" && $0 >= " " }.map(String.init)
+          Parse {
+            "\\"
+            OneOf {
+              "\n".map { "\n" }
+              "\r".map { "\r" }
+              "\t".map { "\t" }
+            }
+          }
+        }
+      } terminator: {
+        "\""
+      }
+    }
+
+    XCTAssertThrowsError(
+      try stringLiteral.parse(
+        """
+        "Hello
+        world"
+        """
+      )
+    ) { error in
+      XCTAssertEqual(
+        #"""
+        error: multiple failures occurred
+
+        error: unexpected input
+         --> input:1:7
+        1 | "Hello
+          |       ^ expected 1 element satisfying predicate
+
+        error: unexpected input
+         --> input:1:7
+        1 | "Hello
+          |       ^ expected "\\"
+
+        error: unexpected input
+         --> input:1:7
+        1 | "Hello
+          |       ^ expected "\""
+        """#,
+        "\(error)"
+      )
+    }
+  }
 }

--- a/Tests/ParsingTests/PrefixTests.swift
+++ b/Tests/ParsingTests/PrefixTests.swift
@@ -11,7 +11,7 @@ final class PrefixTests: XCTestCase {
   func testPrefixUnder() {
     var input = "42 Hi!"[...]
     XCTAssertThrowsError(try Prefix(8).parse(&input))
-    XCTAssertEqual("42 Hi!", input)
+    XCTAssertEqual("", input)
   }
 
   func testPrefixOver() {
@@ -27,7 +27,7 @@ final class PrefixTests: XCTestCase {
         "\(error)"
       )
     }
-    XCTAssertEqual("42 Hi!", input)
+    XCTAssertEqual("", input)
   }
 
   func testPrefixWhile() {
@@ -61,7 +61,7 @@ final class PrefixTests: XCTestCase {
         "\(error)"
       )
     }
-    XCTAssertEqual("42 Hello, world!", input)
+    XCTAssertEqual("", input)
   }
 
   func testPrefixRangeFromWhileSuccess() {


### PR DESCRIPTION
We had a small bug in how the `Prefix` parser was consuming upon failure: it would always consume the minimum number of elements, which is more than the number of elements it actually consumed. This would produce bad error messages that point to the minimum successful position and _not_ the failure position.