### PR TITLE
Use a closure `() -> Output` in `ReplaceError`

### DIFF
--- a/Sources/Parsing/Parsers/ReplaceError.swift
+++ b/Sources/Parsing/Parsers/ReplaceError.swift
@@ -33,8 +33,9 @@ extension Parser {
   /// - Parameter output: An output to return should the upstream parser fail.
   /// - Returns: A parser that never fails.
   @inlinable
-  public func replaceError(with output: Output) -> Parsers.ReplaceError<Self> {
-    .init(output: { _ in output }, upstream: self)
+  public func replaceError(with output: @autoclosure @escaping () -> Output)
+    -> Parsers.ReplaceError<Self> {
+    .init(output: { _ in output() }, upstream: self)
   }
   
   /// A parser that replaces its error with a provided output.

--- a/Sources/Parsing/Parsers/ReplaceError.swift
+++ b/Sources/Parsing/Parsers/ReplaceError.swift
@@ -39,11 +39,9 @@ extension Parser {
   
   /// A parser that replaces its error with a provided output.
   ///
-  /// You can parametrize the ouput value according to the error
-  ///
   /// See ``replaceError(with:)-1wzc1`` for more information.
   ///
-  /// - Parameter output: A function that returns an `Output` value when the parser fails and throws
+  /// - Parameter output: A closure that returns an `Output` value when the parser fails and throws
   /// the error provided as argument.
   /// - Returns: A parser that never fails.
   @inlinable

--- a/Sources/Parsing/Parsers/ReplaceError.swift
+++ b/Sources/Parsing/Parsers/ReplaceError.swift
@@ -34,6 +34,20 @@ extension Parser {
   /// - Returns: A parser that never fails.
   @inlinable
   public func replaceError(with output: Output) -> Parsers.ReplaceError<Self> {
+    .init(output: { _ in output }, upstream: self)
+  }
+  
+  /// A parser that replaces its error with a provided output.
+  ///
+  /// You can parametrize the ouput value according to the error
+  ///
+  /// See ``replaceError(with:)-1wzc1`` for more information.
+  ///
+  /// - Parameter output: A function that returns an `Output` value when the parser fails and throws
+  /// the error provided as argument.
+  /// - Returns: A parser that never fails.
+  @inlinable
+  public func replaceError(with output: @escaping (Error) -> Output) -> Parsers.ReplaceError<Self> {
     .init(output: output, upstream: self)
   }
 }
@@ -45,13 +59,13 @@ extension Parsers {
   /// the ``Parser/replaceError(with:)`` operation, which constructs this type.
   public struct ReplaceError<Upstream: Parser>: Parser {
     @usableFromInline
-    let output: Upstream.Output
+    let output: (Error) -> Upstream.Output
 
     @usableFromInline
     let upstream: Upstream
 
     @usableFromInline
-    init(output: Upstream.Output, upstream: Upstream) {
+    init(output: @escaping (Error) -> Upstream.Output, upstream: Upstream) {
       self.output = output
       self.upstream = upstream
     }
@@ -63,7 +77,7 @@ extension Parsers {
         return try self.upstream.parse(&input)
       } catch {
         input = original
-        return self.output
+        return self.output(error)
       }
     }
   }


### PR DESCRIPTION
This PR adds a version for `replaceError` that takes a closure `(Error) -> Output`, so the user can adapt the result according to the type/value of the errors thrown. 
The constant version is preserved.

I'm preparing a sister PR (#135) that proposes a parser similar to `ReplaceError` but where the user can potentially rethrow another error, or fallback to an `output` value. This should allow the user to implement more logic on the failing side.