### PR TITLE
Add `TransformError` parser

### DIFF
--- a/Sources/Parsing/Parsers/TransformError.swift
+++ b/Sources/Parsing/Parsers/TransformError.swift
@@ -1,0 +1,47 @@
+extension Parser {
+  /// Returns a parser that transforms the error of this parser can throw with a given closure.
+  ///
+  /// This method is similar to ``replaceError(with:)``, but it doesn't offer the same compile-time
+  /// guarantee, as you can either return some `Output` value, or throw another error. 
+  ///
+  /// - Parameter transform: A closure that transforms errors that this parser's throws.
+  /// - Returns: A parser of with a transformed error.
+  @inlinable
+  public func transformError(
+    _ transform: @escaping (Error) throws -> Self.Output
+  ) -> Parsers.TransformError<Self, Output> {
+    .init(upstream: self, transform: transform)
+  }
+}
+
+extension Parsers {
+  /// A parser that transforms the error of another parser with a given closure.
+  ///
+  /// You will not typically need to interact with this type directly. Instead you will usually use
+  /// the ``Parser/transformError(_:)`` operation, which constructs this type.
+  public struct TransformError<Upstream: Parser, Output>: Parser {
+    /// The parser from which this parser receives output.
+    public let upstream: Upstream
+
+    /// The closure that transforms a thrown error from the upstream parser.
+    public let transform: (Error) throws -> Upstream.Output
+
+    @inlinable
+    public init(upstream: Upstream, transform: @escaping (Error) throws -> Upstream.Output) {
+      self.upstream = upstream
+      self.transform = transform
+    }
+
+    @inlinable
+    @inline(__always)
+    public func parse(_ input: inout Upstream.Input) rethrows -> Upstream.Output {
+      let original = input
+      do {
+        return try self.upstream.parse(&input)
+      } catch {
+        input = original
+        return try self.transform(error)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a sister PR from #132. A new `TransformError` parser is introduced. This variant allows the user to either rethrow an error, or return an `Output` value.

The main difference with `ReplaceError` is that this parser can fail.

One can imagine situations where the user transforms errors from two leaf parsers and replace a branch result with a default value according to the error it received. For example:
```swift
Parse(User.init) {
  nameParser.transformError { _ in throw MyError.invalidName }
  ageParser.transformError { _ in throw MyError.invalidAge }
}
.map { ValidatedUser.validUser($0) }
.replaceError { error in
  switch error:
  case MyError.invalidName:
    return ValidatedUser.invalidName
  case MyError.invalidAge:
    return ValidatedUser.invalidAge
}
```
Using validation for this is a bad example, as there are better tools to achieve this, but you get the idea I hope.

As I'm writing this, I don't know if we should allow to return an `Output` too, or if we should force to return an `Error` in the closure instead of throwing it, making it a "pure" failing side parser. We have `Fail` to go from `Input -> Failure` and `ReplaceError` for `Failure -> Ouput`. I don't know if another "transversal" player makes sense, and it is probably better to see `TransformError` as the pendent of `Map` on the failing side[^1] and remove the possibility to return an output value (should it be renamed "MapError" then?). We can always append a `ReplaceError` if we need to go back in the "parsed" side.

I'm making this PR a draft for now.
Let me know what you think!

[^1]: I wonder if there is not a whole world in the failing side, as recent explorations with combining errors are hinting...
