### PR TITLE
Require parsing to end when using non-incremental parsing

### DIFF
--- a/Sources/Parsing/Parser.swift
+++ b/Sources/Parsing/Parser.swift
@@ -198,7 +198,7 @@ extension Parser {
   @inlinable
   public func parse<C: Collection>(_ input: C) rethrows -> Output
   where Input == C.SubSequence {
-    try self.parse(input[...])
+    try Parse { self; End<Input>() }.parse(input[...])
   }
 
   /// Attempts to parse a nebulous collection of data into something more well-structured.
@@ -209,6 +209,6 @@ extension Parser {
   @inlinable
   public func parse<S: StringProtocol>(_ input: S) rethrows -> Output
   where Input == S.SubSequence.UTF8View {
-    try self.parse(input[...].utf8)
+    try Parse { self; End<Input>() }.parse(input[...].utf8)
   }
 }

--- a/Tests/ParsingTests/ParserTests.swift
+++ b/Tests/ParsingTests/ParserTests.swift
@@ -1,0 +1,18 @@
+import Parsing
+import XCTest
+
+final class ParserTests: XCTestCase {
+  func testNonIncrementalParsingValidatesEnd() {
+    XCTAssertThrowsError(try Int.parser().parse("123 Hello")) { error in
+      XCTAssertEqual(
+        """
+        error: unexpected input
+         --> input:1:4
+        1 | 123 Hello
+          |    ^ expected end of input
+        """,
+        "\(error)"
+      )
+    }
+  }
+}


### PR DESCRIPTION
I think this is probably a good change. Swift has a nice way to expose incremental and non-incremental parser interfaces, so when incrementally parsing a collection we can fail if everything wasn't parsed.

This does mean certain parsers need to be more descriptive (_e.g._ add an explicit trailing parser to trim any extra space) but it could also potentially catch more issues.