### PR TITLE
Fix build failure on Xcode 13.3b3 - Swift 5.6

### DIFF
--- a/Sources/Parsing/ParsingError.swift
+++ b/Sources/Parsing/ParsingError.swift
@@ -313,7 +313,10 @@ func format(labels: [String], context: ParsingError.Context) -> String {
       let slice =
         originalInput.startIndex == remainingInput.startIndex
         ? originalInput
-        : originalInput.base[originalInput.startIndex..<remainingInput.startIndex]
+        : Slice(
+          base: originalInput.base,
+          bounds: originalInput.startIndex..<remainingInput.startIndex
+        )
 
       let expectation: String
       if let error = context.underlyingError as? ParsingError,


### PR DESCRIPTION
`originalInput.base[…]` apparently now makes an `ArraySlice`, which is conflicting with the expected `Slice`. 
We can instantiate the `Slice` directly to avoid confusion.

This change should be backward-compatible.