### PR TITLE
Optionally should backtrack when failing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,9 +32,9 @@
         "package": "swift-custom-dump",
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
-          "branch": null,
-          "revision": "e9205f159983984511d86faa8f4bc3eaca475269",
-          "version": "0.4.0"
+          "branch": "main",
+          "revision": "1c384565cf4ea432649aa7ad84c726e7e9934512",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "0.5.0"),
     .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.0"),
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.4.0"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", branch: "main"),
     .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.1"),
   ],
   targets: [

--- a/Sources/Parsing/ParserPrinters/Optionally.swift
+++ b/Sources/Parsing/ParserPrinters/Optionally.swift
@@ -24,7 +24,13 @@ public struct Optionally<Wrapped: Parser>: Parser {
 
   @inlinable
   public func parse(_ input: inout Wrapped.Input) -> Wrapped.Output? {
-    try? self.wrapped.parse(&input)
+    let original = input
+    do {
+      return try self.wrapped.parse(&input)
+    } catch {
+      input = original
+      return nil
+    }
   }
 }
 
@@ -32,6 +38,6 @@ extension Optionally: Printer where Wrapped: Printer {
   @inlinable
   public func print(_ output: Wrapped.Output?, to input: inout Wrapped.Input) rethrows {
     guard let output = output else { return }
-    try? self.wrapped.print(output, to: &input) // TODO: Should this fail?
+    try self.wrapped.print(output, to: &input)
   }
 }

--- a/Tests/ParsingTests/OptionallyTests.swift
+++ b/Tests/ParsingTests/OptionallyTests.swift
@@ -14,4 +14,13 @@ final class OptionalTests: XCTestCase {
     XCTAssertNoDifference(.none, Optionally { Bool.parser() }.parse(&input))
     XCTAssertNoDifference("Hello, world!", Substring(input))
   }
+    
+  func testBacktracking() {
+    var input = "Hello, world!"[...]
+    XCTAssertNoDifference(.none, Optionally {
+      "Hello, "
+      Bool.parser()
+    }.parse(&input))
+    XCTAssertNoDifference("Hello, world!", input)
+  }
 }

--- a/Tests/ParsingTests/OptionallyTests.swift
+++ b/Tests/ParsingTests/OptionallyTests.swift
@@ -16,11 +16,16 @@ final class OptionalTests: XCTestCase {
   }
     
   func testBacktracking() {
-    var input = "Hello, world!"[...]
-    XCTAssertNoDifference(.none, Optionally {
-      "Hello, "
-      Bool.parser()
-    }.parse(&input))
-    XCTAssertNoDifference("Hello, world!", input)
+    let parser = Parse {
+      "Hello,"
+      Optionally {
+        " "
+        Bool.parser()
+      }
+      " world!"
+    }
+    
+    XCTAssertNoDifference(.some(true), try parser.parse("Hello, true world!"))
+    XCTAssertNoDifference(.none, try parser.parse("Hello, world!"))
   }
 }


### PR DESCRIPTION
Like `OneOf`, `Optionally` should be backtracking on failure, since the wrapped `Parser` may consume some of the input before it fails.

I've also updated the `print` to throw any wrapped `print` failures, since if a value is provided, the wrapped printer shouldn't fail if it's valid.