### PR TITLE
Backtracking Finesse

### DIFF
--- a/Sources/Parsing/Parsers/Not.swift
+++ b/Sources/Parsing/Parsers/Not.swift
@@ -26,10 +26,10 @@ public struct Not<Upstream: Parser>: Parser {
   @inlinable
   public func parse(_ input: inout Upstream.Input) throws {
     let original = input
-    defer { input = original }
     do {
       _ = try self.upstream.parse(&input)
     } catch {
+      input = original
       return
     }
     throw ParsingError.expectedInput("not to be processed", from: original, to: input)

--- a/Sources/Parsing/Parsers/OneOfMany.swift
+++ b/Sources/Parsing/Parsers/OneOfMany.swift
@@ -28,19 +28,20 @@ extension Parsers {
     @inlinable
     @inline(__always)
     public func parse(_ input: inout Parsers.Input) throws -> Parsers.Output {
+      let original = input
+      var count = self.parsers.count
       var errors: [Error] = []
-      errors.reserveCapacity(self.parsers.count)
+      errors.reserveCapacity(count)
       for parser in self.parsers {
         do {
-          var i = input
-          let output = try parser.parse(&i)
-          input = i
-          return output
+          return try parser.parse(&input)
         } catch {
+          count -= 1
+          if count > 0 { input = original }
           errors.append(error)
         }
       }
-      throw ParsingError.manyFailed(errors, at: input)
+      throw ParsingError.manyFailed(errors, at: original)
     }
   }
 }

--- a/Tests/ParsingTests/NotTests.swift
+++ b/Tests/ParsingTests/NotTests.swift
@@ -36,7 +36,7 @@ class NotTests: XCTestCase {
     XCTAssertEqual(
       input,
       """
-      // a comment
+       a comment
       let foo = true
       """
     )

--- a/Tests/ParsingTests/OneOfTests.swift
+++ b/Tests/ParsingTests/OneOfTests.swift
@@ -75,6 +75,36 @@ final class OneOfTests: XCTestCase {
     XCTAssertEqual(", Hello!", Substring(input))
   }
 
+  func testOneOfManyLastPartialFailure() {
+    var input = "Berkeley, Hello!"[...]
+    XCTAssertThrowsError(
+      try OneOf {
+        for parser in [Parse { "New "; "York" }, Parse { "Ber"; "lin" }] {
+          parser
+        }
+      }
+      .parse(&input)
+    ) { error in
+      XCTAssertEqual(
+        """
+        error: multiple failures occurred
+
+        error: unexpected input
+         --> input:1:4
+        1 | Berkeley, Hello!
+          |    ^ expected "lin"
+
+        error: unexpected input
+         --> input:1:1
+        1 | Berkeley, Hello!
+          | ^ expected "New "
+        """,
+        "\(error)"
+      )
+    }
+    XCTAssertEqual("keley, Hello!", Substring(input))
+  }
+
   func testOneOfManyFailure() {
     var input = "London, Hello!"[...]
     XCTAssertThrowsError(

--- a/Tests/ParsingTests/ReplaceErrorTests.swift
+++ b/Tests/ParsingTests/ReplaceErrorTests.swift
@@ -1,0 +1,10 @@
+import Parsing
+import XCTest
+
+final class ReplaceErrorTests: XCTestCase {
+  func testBacktracks() {
+    var input = "123"[...]
+    XCTAssertEqual(0, Parse { Int.parser(); "!" }.replaceError(with: 0).parse(&input))
+    XCTAssertEqual("123", input)
+  }
+}


### PR DESCRIPTION
After discussion from #149, we have a better handle on when and where a parser should backtrack. Basically: if a parser can recover from failure, it should backtrack to the `input`'s state before the failure occurred.

This means we can finesse the behavior of backtracking in the few parsers that need to consider it.

- `Optionally` — Not implemented in this PR, but we will merge #149 in soon!
- `replaceError(with:)` — This already had backtracking baked into it because it's a specialization of `OneOf`, though this PR adds a test.
- `Not` — This parser (along with `Peek`) _always_ backtracked, since they shouldn't consume input. But we think there's no reason for `Not` to _always_ backtrack. If it fails it should be safe enough to leave input consumed and rely on upstream `OneOf`s, etc., to do the work of backtracking.
- `OneOfMany` — `OneOf` only backtracks when recovering input to run another parser, which means it will not perform the extra work of backtracking on the final parser should it fail. `OneOfMany`, however, was always backtracking, even when its final parser failed. This PR has added logic to avoid this extra work.