### PR TITLE
Remove duplicate docs from README and Parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ This library aims to write such a story for parsing in Swift. It introduces a si
 
 ## Getting started
 
+> This is an abridged version of the ["Getting Started"][getting-started-docs] article in the library's [documentation][swift-parsing-docs].
+
 Suppose you have a string that holds some user data that you want to parse into an array of `User`s:
 
 ```swift
@@ -114,6 +116,8 @@ var input = input[...]
 try user.parse(&input)  // 1
 input                   // "Blob,true\n2,Blob Jr.,false\n3,Blob Sr.,true"
 ```
+
+> Note that we use a `Substring` instead of `String` because it allows for more efficient mutations and copying. See the article ["String Abstractions"][string-abstractions-docs] for more information.
 
 Next we want to take everything up until the next comma for the user's name, and then consume the comma:
 
@@ -346,4 +350,6 @@ There are a few other parsing libraries in the Swift community that you might al
 
 This library is released under the MIT license. See [LICENSE](LICENSE) for details.
 
+[getting-started-docs]: https://pointfreeco.github.io/swift-parsing/main/documentation/parsing/gettingstarted
+[string-abstractions-docs]: https://pointfreeco.github.io/swift-parsing/main/documentation/parsing/stringabstractions
 [swift-parsing-docs]: https://pointfreeco.github.io/swift-parsing

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ A library for turning nebulous data into well-structured data, with a focus on c
 
 * [Motivation](#motivation)
 * [Getting started](#getting-started)
-* [Design](#design)
-  * [Protocol](#protocol)
-  * [Result builders](#result-builders)
-  * [Error messages](#error-messages)
-  * [Backtracking](#backtracking)
-  * [Low-level versus high-level](#low-level-versus-high-level)
 * [Benchmarks](#benchmarks)
 * [Documentation](#documentation)
 * [Other libraries](#other-libraries)
@@ -254,195 +248,7 @@ README Example.Ad hoc             8029.000 ns ±  44.44 %     163719
 README Example.Scanner           19786.000 ns ±  35.26 %      62125
 ```
 
-That's the basics of parsing a simple string format, but there's a lot more operators and tricks to learn in order to performantly parse larger inputs. View the [benchmarks](Sources/swift-parsing-benchmark) for examples of real life parsing scenarios.
-
-## Design
-
-### Protocol
-
-The design of the library is largely inspired by the Swift standard library and Apple's Combine framework. A parser is represented as a protocol that many types conform to, and then parser transformations (also known as "combinators") are methods that return concrete types conforming to the parser protocol.
-
-For example, to parse all the characters from the beginning of a substring until you encounter a comma you can use the `Prefix` parser:
-
-```swift
-let parser = Prefix { $0 != "," }
-
-var input = "Hello,World"[...]
-try parser.parse(&input)  // "Hello"
-input                     // ",World"
-```
-
-The type of this parser is:
-
-```swift
-Prefix<Substring>
-```
-
-We can `.map` on this parser in order to transform its output, which in this case is the string "Hello":
-
-```swift
-let parser = Prefix { $0 != "," }
-  .map { $0 + "!!!" }
-
-var input = "Hello,World"[...]
-try parser.parse(&input)  // "Hello!!!"
-input                     // ",World"
-```
-
-The type of this parser is now:
-
-```swift
-Parsers.Map<Prefix<Substring>, Substring>
-```
-
-Notice how the type of the parser encodes the operations that we performed. This adds a bit of complexity when using these types, but comes with some performance benefits because Swift can usually optimize away the creation of those nested types.
-
-### Result builders
-
-The library takes advantage of Swift's `@resultBuilder` feature to make constructing complex parsers as fluent as possible, and should be reminiscent of how views are constructed in SwiftUI. The main entry point into building a parser is the `Parse` builder:
-
-```swift
-Parse {
-
-}
-```
-
-In this builder block you can specify parsers that will be run one after another. For example, if you wanted to parse an integer, then a comma, and then a boolean from a string, you can simply do:
-
-```swift
-Parse {
-  Int.parser()
-  ","
-  Bool.parser()
-}
-```
-
-Note that the `String` type conforms to the `Parser` protocol, and represents a parser that consumes that exact string from the beginning of an input if it matches, and otherwise fails.
-
-Many of the parsers and operators that come with the library are configured with parser builders to maximize readability of the parsers. For example, to parse accounting syntax of numbers, where parenthesized numbers are negative, we can use the `OneOf` parser builder:
-
-```swift
-let accountingNumber = OneOf {
-  Int.parser(isSigned: false)
-
-  Parse {
-    "("
-    Int.parser(isSigned: false)
-    ")"
-  }
-  .map { -$0 }
-}
-
-try accountingNumber.parse("100")    // 100
-try accountingNumber.parse("(100)")  // -100
-```
-
-### Error messages
-
-When a parser fails it throws an error containing information about what went wrong. The actual error thrown by the parsers shipped with this library is internal, and so should be considered opaque. To get a human-readable description of the error message you can stringify the error. For example, the following `UInt8` parser fails to parse a string that would cause it to overflow:
-
-```swift
-do {
-  var input = "1234 Hello"[...]
-  let number = try UInt8.parser().parse(&input))
-} catch {
-  print(error)
-  // error: failed to process "UInt8"
-  //  --> input:1:1-4
-  // 1 | 1234 Hello
-  //   | ^^^^ overflowed 255
-}
-``` 
-
-### Backtracking
-
-Backtracking, which is the process of restoring the input to its original value when a parser fails, is very useful, but can lead to performance issues and cause parsers' logic to be more complicated than necessary. For this reason parsers are not required to backtrack.
-
-Instead, if backtracking is needed, one should use the `OneOf` parser, which can try many parsers one after another on a single input, backtracking after each failure and taking the first that succeeds.
-
-By not requiring backtracking of each individual parser we can greatly simply the logic of parsers and we can coalesce all backtracking logic into just a single parser, the ``OneOf`` parser. 
-
-If used naively, backtracking can lead to less performant parsing code. For example, if we wanted to parse two integers from a string that were separated by either a dash "-" or slash "/", then we could write this as:
-
-```swift
-OneOf {
-  Parse { Int.parser(); "-"; Int.parser() } // 1️⃣
-  Parse { Int.parser(); "/"; Int.parser() } // 2️⃣
-}
-```
-
-However, parsing slash-separated integers is not going to be performant because it will first run the entire 1️⃣ parser until it fails, then backtrack to the beginning, and run the 2️⃣ parser. In particular, the first integer will get parsed twice, unnecessarily repeating that work. On the other hand, we can factor out the common work of the parser and localize the backtracking `OneOf` work to make a much more performant parser:
-
-```swift
-Parse {
-  Int.parser()
-  OneOf { "-"; "/" }
-  Int.parser()
-}
-```
-
-### Low-level versus high-level
-
-The library makes it easy to choose which abstraction level you want to work on. Both low-level and high-level have their pros and cons.
-
-Parsing low-level inputs, such as UTF-8 code units, has better performance, but at the cost of potentially losing correctness. The most canonical example of this is trying to parse the character "é", which can be represented in code units as `[233]` or `[101, 769]`. If you don't remember to always parse both representations you may have a bug where you accidentally fail your parser when it encounters a code unit sequence you don't support.
-
-On the other hand, parsing high-level inputs, such as `String`, can guarantee correctness, but at the cost of performance. For example, `String` handles the complexities of extended grapheme clusters and UTF-8 normalization for you, but traversing strings is slower since its elements are variable width.
-
-The library gives you the tools that allow you to choose which abstraction level you want to work on, as well as the ability to fluidly move between abstraction levels where it makes sense.
-
-For example, say we want to parse particular city names from the beginning of a string:
-
-```swift
-enum City {
-  case london
-  case newYork
-  case sanJose
-}
-```
-
-Because "San José" has an accented character, the safest way to parse it is to parse on the `Substring` abstraction level:
-
-```swift
-let city = OneOf {
-  "London".map { City.london }
-  "New York".map { City.newYork }
-  "San José".map { City.sanJose }
-}
-
-var input = "San José,123"[...]
-try city.parse(&input)  // City.sanJose
-input                   // ",123"
-```
-
-However, we are incurring the cost of parsing `Substring` for this entire parser, even though only the "San José" case needs that power. We can refactor this parser so that "London" and "New York" are parsed on the `UTF8View` level, since they consist of only ASCII characters, and then parse "San José" as `Substring`:
-
-```swift
-let city = OneOf {
-  "London".utf8.map { City.london }
-  "New York".utf8.map { City.newYork }
-  FromSubstring { 
-    "San José".map { City.sanJose }
-  }  
-}
-```
-
-The `FromSubstring` parser allows us to temporarily leave the world of parsing UTF-8 and instead work on the higher level `Substring` abstraction, which takes care of normalization of the "é" character.
-
-If we wanted to be _really_ pedantic we could even parse "San Jos" as UTF-8 and then parse only the "é" character as a substring:
-
-```swift
-let city = OneOf {
-  "London".utf8.map { City.london }
-  "New York".utf8.map { City.newYork }
-  Parse(City.sanJose) {
-    "San Jos".utf8
-    FromSubstring { "é" }
-  }
-}
-```
-
-This allows you to parse as much as possible on the more performant, low-level `UTF8View`, while still allowing you to parse on the more correct, high-level `Substring` when necessary.
+That's the basics of parsing a simple string format, but there's a lot more operators and tricks to learn in order to performantly parse larger inputs. Read the [documentation][swift-parsing-docs] to dive more deeply into the concepts of parsing, and view the [benchmarks](Sources/swift-parsing-benchmark) for more examples of real life parsing scenarios.
 
 ## Benchmarks
 
@@ -515,7 +321,7 @@ Xcode Logs.Parser                             3768437.500 ns ±   0.56 %        
 
 The documentation for releases and main are available here:
 
-* [main](https://pointfreeco.github.io/swift-parsing)
+* [main][swift-parsing-docs]
 * [0.7.1](https://pointfreeco.github.io/swift-parsing/0.7.1/documentation/parsing)
 <details>
   <summary>
@@ -539,3 +345,5 @@ There are a few other parsing libraries in the Swift community that you might al
 ## License
 
 This library is released under the MIT license. See [LICENSE](LICENSE) for details.
+
+[swift-parsing-docs]: https://pointfreeco.github.io/swift-parsing

--- a/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
@@ -32,8 +32,8 @@ backtracking your input because it will be handled for you automatically. The pr
 for backtracking is via the ``OneOf`` parser, but there are a few other parsers that also backtrack 
 internally.
 
-One such example is the ``Optionally`` parser which transforms any parser into one that cannot fail 
-by returning `nil` if it does fail:
+One such example is the ``Optionally`` parser, which transforms any parser into one that cannot fail 
+by catching any thrown errors and returning `nil`:
 
 ```swift
 let parser = Parse {
@@ -51,7 +51,7 @@ the parser ran. In particular, if the `Bool.parser()` fails then it will make su
 consuming the leading space " " so that later parsers can try.
 
 Another example of a parser that internally backtracks is the ``Parser/replaceError(with:)`` 
-opreator, which coalesces any error thrown by a parser into a default output value:
+operator, which coalesces any error thrown by a parser into a default output value:
 
 ```swift
 let parser = Parse {
@@ -65,8 +65,7 @@ try parser.parse("Hello, world!")      // false
 try parser.parse("Hello, true world!") // true
 ```
 
-It backtracks the input to its original value when the parser fails so that later parsers can 
-try.
+It backtracks the input to its original value when the parser fails so that later parsers can try.
 
 The only time you need to worry about explicitly backtracking input is when making your own
 ``Parser`` conformances. As a general rule of thumb, if your parser recovers from all failures

--- a/Sources/Parsing/Parser.swift
+++ b/Sources/Parsing/Parser.swift
@@ -1,12 +1,5 @@
 /// Declares a type that can parse an `Input` value into an `Output` value.
 ///
-/// * [Getting started](#Getting-started)
-/// * [String abstraction levels](#String-abstraction-levels)
-/// * [Error messages](#Error-messages)
-/// * [Backtracking](#Backtracking)
-///
-/// ## Getting started
-///
 /// A parser attempts to parse a nebulous piece of data, represented by the `Input` associated type,
 /// into something more well-structured, represented by the `Output` associated type. The parser
 /// implements the ``parse(_:)-76tcw`` method, which is handed an `inout Input`, and its job is to
@@ -20,152 +13,24 @@
 /// ```swift
 /// var input: Substring = "123 Hello world"
 ///
-/// try Int.parser().parse(&input)  // 123
-/// input                           // " Hello world"
+/// try Int.parser().parse(&input) // 123
+/// input // " Hello world"
 /// ```
 ///
-/// Note that this parser works on `Substring` rather than `String` because substrings expose efficient ways
-/// of removing characters from its beginning. Substrings are "views" into a string, specificed by start and
-/// end indices. Operations like `removeFirst`, `removeLast` and others can be implemented efficiently on
-/// substrings because they simply move the start and end indices, whereas their implementation on strings
-/// must make a copy of the string with the characters removed.
+/// Note that this parser works on `Substring` rather than `String` because substrings expose
+/// efficient ways of removing characters from its beginning. Substrings are "views" into a string,
+/// specificed by start and end indices. Operations like `removeFirst`, `removeLast` and others can
+/// be implemented efficiently on substrings because they simply move the start and end indices,
+/// whereas their implementation on strings must make a copy of the string with the characters
+/// removed.
 ///
-/// ## String abstraction levels
+/// To explore the concepts of parsers more deeply read the following articles:
 ///
-/// It is possible to seamlessly parse on different abstraction levels of strings. Working on high-level and
-/// low-level `String` abstractions each have their pros and cons.
-///
-/// Parsing low-level abstractions, such as `UTF8View` or a collection of UTF-8 code units, has better
-/// performance but at the cost of potentially losing correctness. The most canonical example of this is
-/// trying to parse the character "é", which can be represented in code units as `[233]` or `[101, 769]`.
-/// If you don't remember to always parse both representations you may have a bug where you accidentally
-/// fail your parser when it encounters a code unit sequence you don't support.
-///
-/// On the other hand, parsing high-level inputs, such as `Substring` or `UnicodeScalarView`, can guarantee
-/// correctness, but at the cost of performance. For example, `Substring` handles the complexities of extended
-/// grapheme clusters and UTF-8 normalization for you, but traversing strings is slower since its elements
-/// are variable width.
-///
-/// The library gives you the tools that allow you to choose which abstraction level you want to work on, as
-/// well as the ability to fluidly move between abstraction levels where it makes sense.
-///
-/// For example, say we want to parse particular city names from the beginning of a string:
-///
-/// ```swift
-/// enum City {
-///   case london
-///   case newYork
-///   case sanJose
-/// }
-/// ```
-///
-/// Because "San José" has an accented character, the safest way to parse it is to parse on the `Substring`
-/// abstraction level:
-///
-/// ```swift
-/// let city = OneOf {
-///   "London".map { City.london }
-///   "New York".map { City.newYork }
-///   "San José".map { City.sanJose }
-/// }
-///
-/// var input = "San José,123"[...]
-/// try city.parse(&input)  // City.sanJose
-/// input                   // ",123"
-/// ```
-///
-/// However, we are incurring the cost of parsing `Substring` for this entire parser, even though only the
-/// "San José" case needs that power. We can refactor this parser so that "London" and "New York" are parsed
-/// on the `UTF8View` level, since they consist of only ASCII characters, and then parse "San José" as
-/// `Substring`:
-///
-/// ```swift
-/// let city = OneOf {
-///   "London".utf8.map { City.london }
-///   "New York".utf8.map { City.newYork }
-///   FromSubstring {
-///     "San José".map { City.sanJose }
-///   }
-/// }
-/// ```
-///
-/// The `FromSubstring` parser allows us to temporarily leave the world of parsing UTF-8 and instead work on
-/// the higher level `Substring` abstraction, which takes care of normalization of the "é" character.
-///
-/// If we wanted to be _really_ pedantic we could even parse "San Jos" as UTF-8 and then parse only the "é"
-/// character as a substring:
-///
-/// ```swift
-/// let city = OneOf {
-///   "London".utf8.map { City.london }
-///   "New York".utf8.map { City.newYork }
-///   Parse(City.sanJose) {
-///     "San Jos".utf8
-///     FromSubstring { "é" }
-///   }
-/// }
-/// ```
-///
-/// This allows you to parse as much as possible on the more performant, low-level `UTF8View`, while still
-/// allowing you to parse on the more correct, high-level `Substring` when necessary.
-///
-/// ## Error messages
-///
-/// When a parser fails it throws an error containing information about what went wrong. The actual error
-/// thrown by the parsers shipped with this library is internal, and so should be considered opaque. To get
-/// a human-readable description of the error message you can stringify the error. For example, the following
-/// `UInt8` parser fails to parse a string that would cause it to overflow:
-///
-/// ```swift
-/// do {
-///   var input = "1234 Hello"[...]
-///   let number = try UInt8.parser().parse(&input))
-/// } catch {
-///   print(error)
-///
-///   // error: failed to process "UInt8"
-///   //  --> input:1:1-4
-///   // 1 | 1234 Hello
-///   //   | ^^^^ overflowed 255
-/// }
-/// ```
-///
-/// ## Backtracking
-///
-/// Parsers may consume input even if they throw an error, and you should not depend on a parser
-/// restoring the input to the original value when failing. The process of restoring the input to the
-/// original value is known as "backtracking". Backtracking can be handy when wanting to try many parsers
-/// on the same input, and one usually does this by using the ``OneOf`` parser, which automatically backtracks
-/// when one of its parsers fails.
-///
-/// By not requiring backtracking of each individual parser we can greatly simply the logic of parsers and we
-/// can coalesce all backtracking logic into just a single parser, the ``OneOf`` parser. If you really need
-/// backtracking capabilities then we recommend using the ``OneOf`` parser to control backtracking.
-///
-/// If used naively, backtracking can lead to less performant parsing code. For example, if we wanted to
-/// parse two integers from a string that were separated by either a dash "-" or slash "/", then we could
-/// write this as:
-///
-/// ```swift
-/// OneOf {
-///   Parse { Int.parser(); "-"; Int.parser() } // 1️⃣
-///   Parse { Int.parser(); "/"; Int.parser() } // 2️⃣
-/// }
-/// ```
-///
-/// However, parsing slash-separated integers is not going to be performant because it will first run the
-/// entire 1️⃣ parser until it fails, then backtrack to the beginning, and run the 2️⃣ parser. In particular,
-/// the first integer will get parsed twice, unnecessarily repeating that work. On the other hand, we can
-/// factor out the common work of the parser and localize the backtracking ``OneOf`` work to make a much more
-/// performant parser:
-///
-/// ```swift
-/// Parse {
-///   Int.parser()
-///   OneOf { "-"; "/" }
-///   Int.parser()
-/// }
-/// ```
+/// * <doc:GettingStarted>
+/// * <doc:Design>
+/// * <doc:StringAbstractions>
+/// * <doc:ErrorMessages>
+/// * <doc:Backtracking>
 @rethrows public protocol Parser {
   /// The kind of values this parser receives.
   associatedtype Input


### PR DESCRIPTION
The DocC articles are now the source-of-truth for parser info, and so we can remove a bunch of duplicated info from the README and `Parser` docs.