### PR TITLE
Auto-trim trailing markdown whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ test-swift:
 format:
 	swift format --in-place --recursive \
 		./Package.swift ./Sources ./Tests
+	find . -type f -name '*.md' -print0 | xargs -0 perl -pi -e 's/ +$$//'
 
 generate-variadics:
 	swift run variadics-generator > Sources/Parsing/Builders/Variadics.swift

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ input                   // "Blob,true\n2,Blob Jr.,false\n3,Blob Sr.,true"
 Next we want to take everything up until the next comma for the user's name, and then consume the comma:
 
 ```swift
-let user = Parse { 
+let user = Parse {
   Int.parser()
   ","
   Prefix { $0 != "," }

--- a/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
@@ -5,7 +5,7 @@ unnecessary.
 
 ## Overview
 
-Backtracking is the process of restoring an input to its original value when parsing fails. While it 
+Backtracking is the process of restoring an input to its original value when parsing fails. While it
 can be very useful, backtracking can lead to more complicated parser logic than necessary, and
 backtracking too often can lead to performance issues. For this reason, most parsers are not
 required to backtrack, and can therefore fail _and_ still consume from the input.
@@ -27,12 +27,12 @@ let currency = OneOf {
 ## When to backtrack in your parsers?
 
 If you only use the parsers and operators that ship with this library, and in particular you do not
-create custom conformances to the ``Parser`` protocol, then you never need to worry about explicitly 
-backtracking your input because it will be handled for you automatically. The primary way to allow 
-for backtracking is via the ``OneOf`` parser, but there are a few other parsers that also backtrack 
+create custom conformances to the ``Parser`` protocol, then you never need to worry about explicitly
+backtracking your input because it will be handled for you automatically. The primary way to allow
+for backtracking is via the ``OneOf`` parser, but there are a few other parsers that also backtrack
 internally.
 
-One such example is the ``Optionally`` parser, which transforms any parser into one that cannot fail 
+One such example is the ``Optionally`` parser, which transforms any parser into one that cannot fail
 by catching any thrown errors and returning `nil`:
 
 ```swift
@@ -50,7 +50,7 @@ If the parser captured inside ``Optionally`` fails then it backtracks the input 
 the parser ran. In particular, if the `Bool.parser()` fails then it will make sure to undo
 consuming the leading space " " so that later parsers can try.
 
-Another example of a parser that internally backtracks is the ``Parser/replaceError(with:)`` 
+Another example of a parser that internally backtracks is the ``Parser/replaceError(with:)``
 operator, which coalesces any error thrown by a parser into a default output value:
 
 ```swift
@@ -75,7 +75,7 @@ This is exactly how ``OneOf``, ``Optionally`` and ``Parser/replaceError(with:)``
 ## Performance
 
 If used naively, backtracking can lead to less performant parsing code. For example, if we wanted to
-parse two integers from a string that were separated by either a dash "-" or slash "/", then we 
+parse two integers from a string that were separated by either a dash "-" or slash "/", then we
 could write this as:
 
 ```swift
@@ -85,11 +85,11 @@ OneOf {
 }
 ```
 
-However, parsing slash-separated integers is not going to be performant because it will first run 
-the entire 1️⃣ parser until it fails, then backtrack to the beginning, and run the 2️⃣ parser. In 
-particular, the first integer will get parsed twice, unnecessarily repeating that work. 
+However, parsing slash-separated integers is not going to be performant because it will first run
+the entire 1️⃣ parser until it fails, then backtrack to the beginning, and run the 2️⃣ parser. In
+particular, the first integer will get parsed twice, unnecessarily repeating that work.
 
-On the  other hand, we can factor out the common work of the parser and localize the backtracking 
+On the  other hand, we can factor out the common work of the parser and localize the backtracking
 ``OneOf`` work to make a much more performant parser:
 
 ```swift

--- a/Sources/Parsing/Documentation.docc/Articles/Design.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Design.md
@@ -4,12 +4,12 @@ Learn how the library is designed, including its use of protocols, result builde
 
 ## Protocol
 
-The design of the library is largely inspired by the Swift standard library and Apple's Combine 
+The design of the library is largely inspired by the Swift standard library and Apple's Combine
 framework. A parser is represented as a protocol that many types conform to, and then parser
-transformations (also known as "combinators") are methods that return concrete types conforming to 
+transformations (also known as "combinators") are methods that return concrete types conforming to
 the parser protocol.
 
-For example, to parse all the characters from the beginning of a substring until you encounter a 
+For example, to parse all the characters from the beginning of a substring until you encounter a
 comma you can use the `Prefix` parser:
 
 ```swift
@@ -26,7 +26,7 @@ The type of this parser is:
 Prefix<Substring>
 ```
 
-We can `.map` on this parser in order to transform its output, which in this case is the string 
+We can `.map` on this parser in order to transform its output, which in this case is the string
 "Hello":
 
 ```swift
@@ -44,8 +44,8 @@ The type of this parser is now:
 Parsers.Map<Prefix<Substring>, Substring>
 ```
 
-Notice that the type of the parser encodes the operations that we performed. This adds a bit of 
-complexity when using these types, but comes with some performance benefits because Swift can 
+Notice that the type of the parser encodes the operations that we performed. This adds a bit of
+complexity when using these types, but comes with some performance benefits because Swift can
 usually inline and optimize away the creation of those nested types.
 
 ## Result Builders
@@ -60,7 +60,7 @@ Parse {
 }
 ```
 
-In this builder block you can specify parsers that will be run one after another. For example, if 
+In this builder block you can specify parsers that will be run one after another. For example, if
 you wanted to parse an integer, then a comma, and then a boolean from a string, you can simply do:
 
 ```swift
@@ -71,10 +71,10 @@ Parse {
 }
 ```
 
-Note that the `String` type conforms to the ``Parser`` protocol, and represents a parser that 
+Note that the `String` type conforms to the ``Parser`` protocol, and represents a parser that
 consumes that exact string from the beginning of an input if it matches, and otherwise fails.
 
-Many of the parsers and operators that come with the library are configured with parser builders 
+Many of the parsers and operators that come with the library are configured with parser builders
 to maximize readability of the parsers. For example, to parse accounting syntax of numbers, where
 parenthesized numbers are negative, we can use the ``OneOf`` parser builder:
 
@@ -96,7 +96,7 @@ try accountingNumber.parse("(100)")  // -100
 
 ## Operators
 
-Parser operators (also called "combinators") are methods defined on the ``Parser`` protocol that 
+Parser operators (also called "combinators") are methods defined on the ``Parser`` protocol that
 return a parser. For example, the ``Parser/map(_:)`` operator is a method that returns something
 called a ``Parsers/Map``:
 
@@ -110,7 +110,7 @@ extension Parser {
 }
 ```
 
-And ``Parsers/Map`` is a dedicated type that implements the logic of the map operation. In 
+And ``Parsers/Map`` is a dedicated type that implements the logic of the map operation. In
 particular, in runs the upstream parser and then transforms its output:
 
 ```swift

--- a/Sources/Parsing/Documentation.docc/Articles/ErrorMessages.md
+++ b/Sources/Parsing/Documentation.docc/Articles/ErrorMessages.md
@@ -1,12 +1,12 @@
 # Error messages
 
-Learn how the library reports parsing errors and how to integrate your own custom error messages 
-into parsers. 
+Learn how the library reports parsing errors and how to integrate your own custom error messages
+into parsers.
 
 ## Overview
 
-When a parser fails it throws an error containing information about what went wrong. The actual 
-error thrown by the parsers shipped with this library is internal, and so it should be considered 
+When a parser fails it throws an error containing information about what went wrong. The actual
+error thrown by the parsers shipped with this library is internal, and so it should be considered
 opaque. To get a human-readable debug description of the error message you can stringify the error.
 For  example, the following `UInt8` parser fails to parse a string that would cause it to overflow:
 
@@ -55,12 +55,12 @@ do {
   print(error))
 
   // error: multiple failures occurred
-  // 
+  //
   // error: unexpected input
   //  --> input:1:5
   // 1 | (100]
   //   |     ^ expected ")"
-  // 
+  //
   // error: unexpected input
   //  --> input:1:1
   // 1 | (100]
@@ -154,7 +154,7 @@ output.count // 2
 input // "\n3,Blob Sr.,tru"
 ```
 
-However, by adding a terminator to this `users` parser an error will be throw that points to the 
+However, by adding a terminator to this `users` parser an error will be throw that points to the
 exact spot where the typo occurred:
 
 ```swift
@@ -176,15 +176,15 @@ let output = try users.parse(&input)
 
 ## Throwing your own errors
 
-Although the error type thrown by the parsers that ship in this library is currently internal, and 
+Although the error type thrown by the parsers that ship in this library is currently internal, and
 so should be thought of as opaque, it is still possible to throw your own errors. Your errors will
 automatically be reformatted and contextualized to show exactly where the error occurred.
 
-For example, suppose we wanted a parser that only parsed the digits 0-9 from the beginning of a 
+For example, suppose we wanted a parser that only parsed the digits 0-9 from the beginning of a
 string and transformed it into an integer. This is subtly different from `Int.parser()` which
 supports negative numbers, exponential formatting, and more.
 
-Constructing a `Digits` parser is easy enough, and we can introduce a custom struct error for 
+Constructing a `Digits` parser is easy enough, and we can introduce a custom struct error for
 customizing the message displayed:
 
 ```swift

--- a/Sources/Parsing/Documentation.docc/Articles/GettingStarted.md
+++ b/Sources/Parsing/Documentation.docc/Articles/GettingStarted.md
@@ -39,7 +39,7 @@ struct User {
 }
 ```
 
-A naive approach to this would be a nested use of `.split(separator:)`, and then a little bit of 
+A naive approach to this would be a nested use of `.split(separator:)`, and then a little bit of
 extra work to convert strings into integers and booleans:
 
 ```swift
@@ -57,15 +57,15 @@ let users = input
   }
 ```
 
-Not only is this code a little messy, but it is also inefficient since we are allocating arrays for 
+Not only is this code a little messy, but it is also inefficient since we are allocating arrays for
 the `.split` and then just immediately throwing away those values.
 
-It would be more straightforward and efficient to instead describe how to consume bits from the 
+It would be more straightforward and efficient to instead describe how to consume bits from the
 beginning of the input and convert that into users. This is what this parser library excels at 😄.
 
-We can start by describing what it means to parse a single row, first by parsing an integer off the 
-front of the string, and then parsing a comma. We can do this by using the `Parse` type, which acts 
-as an entry point into describing a list of parsers that you want to run one after the other to 
+We can start by describing what it means to parse a single row, first by parsing an integer off the
+front of the string, and then parsing a comma. We can do this by using the `Parse` type, which acts
+as an entry point into describing a list of parsers that you want to run one after the other to
 consume from an input:
 
 ```swift
@@ -85,11 +85,11 @@ try user.parse(&input)  // 1
 input                   // "Blob,true\n2,Blob Jr.,false\n3,Blob Sr.,true"
 ```
 
-Next we want to take everything up until the next comma for the user's name, and then consume the 
+Next we want to take everything up until the next comma for the user's name, and then consume the
 comma:
 
 ```swift
-let user = Parse { 
+let user = Parse {
   Int.parser()
   ","
   Prefix { $0 != "," }
@@ -109,7 +109,7 @@ let user = Parse {
 }
 ```
 
-Currently this will parse a tuple `(Int, Substring, Bool)` from the input, and we can `.map` on 
+Currently this will parse a tuple `(Int, Substring, Bool)` from the input, and we can `.map` on
 that to turn it into a `User`:
 
 ```swift
@@ -151,7 +151,7 @@ let user = Parse(User.init(id:name:isAdmin:)) {
 }
 ```
 
-That is enough to parse a single user from the input string, leaving behind a newline and the final 
+That is enough to parse a single user from the input string, leaving behind a newline and the final
 two users:
 
 ```swift
@@ -159,7 +159,7 @@ try user.parse(&input) // User(id: 1, name: "Blob", isAdmin: true)
 input // "\n2,Blob Jr.,false\n3,Blob Sr.,true"
 ```
 
-To parse multiple users from the input we can use the `Many` parser to run the user parser many 
+To parse multiple users from the input we can use the `Many` parser to run the user parser many
 times:
 
 ```swift
@@ -173,7 +173,7 @@ try users.parse(&input) // [User(id: 1, name: "Blob", isAdmin: true), ...]
 input // ""
 ```
 
-Now this parser can process an entire document of users, and the code is simpler and more 
+Now this parser can process an entire document of users, and the code is simpler and more
 straightforward than the version that uses `.split` and `.compactMap`.
 
 Even better, it's more performant. We've written [benchmarks][benchmarks-readme] for these two
@@ -186,7 +186,7 @@ README Example.Parser: Substring 3426.000 ns ±  63.40 %     385395
 README Example.Ad hoc            7631.000 ns ±  47.01 %     169332
 ```
 
-Further, if you are willing write your parsers against `UTF8View` instead of `Substring`, you can 
+Further, if you are willing write your parsers against `UTF8View` instead of `Substring`, you can
 eke out even more performance, more than doubling the speed:
 
 ```
@@ -276,7 +276,7 @@ let field = OneOf {
 .map(String.init)
 ```
 
-We can use this parser in the `user` parser, and now it properly handles quoted and non-quoted 
+We can use this parser in the `user` parser, and now it properly handles quoted and non-quoted
 fields:
 
 ```swift
@@ -295,7 +295,7 @@ It was quite straightforward to improve the `user` parser to handle quoted field
 with our ad hoc `split`/`compactMap` parser, and even the `Scanner`-based parser, would be a lot
 more difficult.
 
-That's the basics of parsing a simple string format, but there's a lot more operators and tricks to 
+That's the basics of parsing a simple string format, but there's a lot more operators and tricks to
 learn in order to performantly parse larger inputs. View the [benchmarks][benchmarks] for examples
 of real-life parsing scenarios.
 

--- a/Sources/Parsing/Documentation.docc/Articles/StringAbstractions.md
+++ b/Sources/Parsing/Documentation.docc/Articles/StringAbstractions.md
@@ -1,6 +1,6 @@
 # String Abstractions
 
-Learn how to write parsers on different levels of string abstractions, giving you the ability to 
+Learn how to write parsers on different levels of string abstractions, giving you the ability to
 trade performance for correctness where needed.
 
 ## Levels of abstraction
@@ -25,10 +25,10 @@ However, there are tradeoffs to using each type:
 
     For example, complex elements that can be represented by a single `Character`, such as "🇺🇸",
     are represented by multiple `Unicode.Scalar` elements, "🇺" and "🇸". When put together they
-    form the single extended grapheme cluster of the flag character. 
+    form the single extended grapheme cluster of the flag character.
 
     Further, some `Character`s have multiple representations as collections of unicode scalars. For
-    example, an "e" with an accute access only has one visual representation, yet there are two 
+    example, an "e" with an accute access only has one visual representation, yet there are two
     different sequences of unicode scalars that can represent that character:
 
     ```swift
@@ -43,7 +43,7 @@ However, there are tradeoffs to using each type:
 
     ```swift
     let e1 = "\u{00E9}"
-    let e2 = "e\u{0301}" 
+    let e2 = "e\u{0301}"
     e1 == e2 // true
     e1.unicodeScalars.elementsEqual(e2.unicodeScalars) // false
     ```
@@ -51,7 +51,7 @@ However, there are tradeoffs to using each type:
     So, when parsing on the level of `UnicodeScalarView` you have to be aware of these subtleties in
     order to form a correct parser.
 
-  * `UTF8View` is a collection of `Unicode.UTF8.CodeUnit`s, which is just a typealias for `UInt8`, 
+  * `UTF8View` is a collection of `Unicode.UTF8.CodeUnit`s, which is just a typealias for `UInt8`,
     _i.e._, a single byte. This is an even lower-level representation of strings than
     `UnicodeScalarView`, and scanning these collections is quite efficient, but at the cost of even
     more complexity.
@@ -114,7 +114,7 @@ let city = OneOf {
 }
 ```
 
-We have accidentally introduced a bug into the parser in which it recognizes one version of 
+We have accidentally introduced a bug into the parser in which it recognizes one version of
 "San José", but not the other:
 
 ```swift
@@ -137,7 +137,7 @@ city.parse("San Jos\u{00E9}".utf8)  // ✅
 city.parse("San Jose\u{0301}".utf8) // ✅
 ```
 
-This does work, but you are now responsible for understanding the ins and outs of UTF-8 
+This does work, but you are now responsible for understanding the ins and outs of UTF-8
 normalization. UTF-8 is incredibly complex and Swift does a lot of work to hide that complexity
 from you.
 
@@ -160,7 +160,7 @@ city.parse("San Jose\u{0301}".utf8) // ✅
 This will run the "San José" parser on the level of `Substring`, meaning it will handle all the
 complexities of UTF8 normalization so that we don't have to think about it.
 
-If we want to be _really_ pedantic we can even decide to parse only the "é" character on the 
+If we want to be _really_ pedantic we can even decide to parse only the "é" character on the
 level of `Substring` and leave everything else to `UTF8View`:
 
 ```swift
@@ -178,6 +178,6 @@ city.parse("San Jos\u{00E9}".utf8)  // ✅
 city.parse("San Jose\u{0301}".utf8) // ✅
 ```
 
-We don't necessarily recommend being this pedantic in general, at least not without benchmarking to 
-make sure it is worth it. But it does demonstrate how you can be very precise with which abstraction 
+We don't necessarily recommend being this pedantic in general, at least not without benchmarking to
+make sure it is worth it. But it does demonstrate how you can be very precise with which abstraction
 levels you want to work on.

--- a/Sources/Parsing/Documentation.docc/Parsing.md
+++ b/Sources/Parsing/Documentation.docc/Parsing.md
@@ -1,6 +1,6 @@
 # ``Parsing``
 
-A library for turning nebulous data into well-structured data, with a focus on composition, 
+A library for turning nebulous data into well-structured data, with a focus on composition,
 performance, generality, and ergonomics.
 
 ## Additional Resources
@@ -11,7 +11,7 @@ performance, generality, and ergonomics.
 
 ## Overview
 
-Parsing with this library is performed by listing out many small parsers that describe how to 
+Parsing with this library is performed by listing out many small parsers that describe how to
 incrementally consume small bits from the beginning of an input string. For example, suppose you
 have a string that holds some user data that you want to parse into an array of `User`s:
 
@@ -29,7 +29,7 @@ struct User {
 }
 ```
 
-A parser can be constructed for transforming the input string into an array of users in succinct 
+A parser can be constructed for transforming the input string into an array of users in succinct
 and fluent API:
 
 ```swift
@@ -45,7 +45,7 @@ let users = Many {
   user
 } separator: {
   "\n"
-} terminator: { 
+} terminator: {
   End()
 }
 
@@ -58,7 +58,7 @@ This says that to parse a user we:
 * then a comma
 * then everything up to the next comma
 * then another comma
-* and finally a boolean. 
+* and finally a boolean.
 
 And to parse an entire array of users we:
 
@@ -67,7 +67,7 @@ And to parse an entire array of users we:
 * and once the `user` and separator parsers have consumed all they can we run the terminator
 parser to verify there is no more input to consume.
 
-Further, if the input is malformed, like say we mistyped one of the booleans, then the parser emits 
+Further, if the input is malformed, like say we mistyped one of the booleans, then the parser emits
 an error that describes exactly what went wrong:
 
 ```swift


### PR DESCRIPTION
Since Xcode doesn't trim markdown files, let's automate this at the CI level.