### PR TITLE
Adding more structure and hierarchy to the documentation catalogue

### DIFF
--- a/Sources/Parsing/Documentation.docc/Collections/Functional.md
+++ b/Sources/Parsing/Documentation.docc/Collections/Functional.md
@@ -1,0 +1,42 @@
+# Composable Parsers
+
+Compose parsers in a more functional way with the likes of map, zip, flatMap, etc.
+
+## Overview
+
+Use classic functions like map, flatMap, and more.
+
+Below is an example of using a `CompactMap` parser for each of the color components in a hex color representation: 
+
+```swift
+struct Color {
+  let red, green, blue: UInt8
+}
+
+let hexPrimary = Prefix(2)
+  .compactMap { UInt8($0, radix: 16) }
+
+let hexColor = Parse(Color.init(red:green:blue:)) {
+  "#"
+  hexPrimary
+  hexPrimary
+  hexPrimary
+}
+```
+
+The parser captures a `Color(red: 255, green: 0, blue: 0)` value out of the "#FF0000" input. 
+
+## Topics
+
+### Functional Parsers
+
+- ``Parsers/Map``
+- ``Parsers/FlatMap``
+- ``Parsers/CompactMap``
+- ``Parsers/Filter``
+- ``Parsers/Pipe``
+
+### Transformation Parsers
+
+- ``Parsers/Pullback``
+- ``Parsers/ReplaceError``

--- a/Sources/Parsing/Documentation.docc/Collections/ParsingData.md
+++ b/Sources/Parsing/Documentation.docc/Collections/ParsingData.md
@@ -1,0 +1,68 @@
+# Capturing Data
+
+Capture strongly-typed chunks of data from your input string. 
+
+## Overview
+
+Use these parsers to descibe the parts of the input you want to capture and their expected format.
+
+For example, you have a string describing a user with an ID, name, and admin flag:
+
+```text
+1  ,Peter,isAdmin:true
+```
+
+You want to capture some parts of the string like "1", "Peter" and "true" and skip others like the whitespace after the ID and the "isAdmin:" string. 
+
+Combine capturing parsers to sequentially describe the source format like below:
+
+```swift
+let values = Parse {
+  Int.parser()
+  Skip { Whitespace() }
+  ","
+  Prefix { $0 != "," }
+  ",isAdmin:"
+  Bool.parser()
+}
+```
+
+To directly convert the captured values into a `User` struct with matching properties use `Parse/init(_:with:)` like so:
+
+```swift
+let user = Parse(User.init) {
+  ... parsers ...
+}
+```
+
+## Topics
+
+### Capturing continuous data 
+
+- ``Prefix``
+- ``PrefixUpTo``
+- ``PrefixThrough``
+- ``StartsWith``
+- ``Rest``
+
+### Capturing Typed Values
+
+You will not typically need to interact with these parsers directly. Instead use the extensions on each target type like `Bool.parser()`, `Int.parser()`, etc. which construct the desired parser.
+
+- ``Parsers/BoolParser``
+- ``Parsers/IntParser``
+- ``Parsers/DoubleParser``
+- ``Parsers/FloatParser``
+- ``Parsers/Float80Parser``
+- ``Parsers/UUIDParser``
+
+### Consuming Whitespace
+
+- ``Whitespace``
+- ``Newline``
+
+### Specialized String Parsers
+
+- ``FromSubstring``
+- ``FromUTF8View``
+- ``FromUnicodeScalarView``

--- a/Sources/Parsing/Documentation.docc/Collections/ParsingLogic.md
+++ b/Sources/Parsing/Documentation.docc/Collections/ParsingLogic.md
@@ -1,0 +1,41 @@
+# Parsing Logic
+
+Describe parsing logic like following one of multiple possible parsing paths or reaching the end of the input.
+
+## Overview
+
+Use these parsers to describe the stucture of the input format that doesn't neccessarily represent interesting data or bits that need to be captured. 
+
+## Topics
+
+### Create a Parser
+
+- ``Parse``
+- ``AnyParser``
+
+### Structure
+
+- ``First``
+- ``End``
+- ``Skip``
+- ``Stream``
+
+### Logic
+
+- ``Many``
+- ``Not``
+- ``OneOf``
+- ``Parsers/OneOfMany``
+- ``Optionally``
+- ``Peek``
+
+### Meta
+
+- ``Fail``
+- ``Always``
+- ``Lazy``
+- ``Parsers/OptionalVoid``
+
+### Deprecated
+
+* ``Conditional``

--- a/Sources/Parsing/Documentation.docc/Extensions/OneOf.md
+++ b/Sources/Parsing/Documentation.docc/Extensions/OneOf.md
@@ -1,0 +1,7 @@
+# ``Parsing/OneOf``
+
+## Topics
+
+### Builder
+
+- ``OneOfBuilder``

--- a/Sources/Parsing/Documentation.docc/Extensions/Parse.md
+++ b/Sources/Parsing/Documentation.docc/Extensions/Parse.md
@@ -1,0 +1,7 @@
+# ``Parsing/Parse``
+
+## Topics
+
+### Builder
+
+- ``ParserBuilder``

--- a/Sources/Parsing/Documentation.docc/Extensions/Parser.md
+++ b/Sources/Parsing/Documentation.docc/Extensions/Parser.md
@@ -1,0 +1,25 @@
+# ``Parsing/Parser``
+
+## Topics
+
+### Parsing Data
+
+- ``parse(_:)-76tcw``
+- ``parse(_:)-2wzcq``
+- ``parse(_:)-6h1d0``
+
+### Input and Output
+
+- ``Input``
+- ``Output``
+- ``replaceError(with:)``
+- ``eraseToAnyParser()``
+
+### Composing Parsers
+
+- ``map(_:)``
+- ``flatMap(_:)``
+- ``compactMap(_:)``
+- ``filter(_:)``
+- ``pipe(_:)``
+- ``pullback(_:)``

--- a/Sources/Parsing/Documentation.docc/Parsing.md
+++ b/Sources/Parsing/Documentation.docc/Parsing.md
@@ -3,7 +3,7 @@
 A library for turning nebulous data into well-structured data, with a focus on composition,
 performance, generality, and ergonomics.
 
-## Additional Resources
+## Resources
 
 - [GitHub Repo](https://github.com/pointfreeco/swift-parsing/)
 - [Discussions](https://github.com/pointfreeco/swift-parsing/discussions)
@@ -11,8 +11,15 @@ performance, generality, and ergonomics.
 
 ## Overview
 
-Parsing with this library is performed by listing out many small parsers that describe how to
-incrementally consume small bits from the beginning of an input string. For example, suppose you
+Combine many small parsers that describe how to incrementally consume an input string and capture the bits that you are interested in as strongly-typed Swift data. 
+
+Start parsing with <doc:GettingStarted> which offers a detailed kickstarer with the library.
+
+## Basics 
+
+``Parsing`` doesn't assume any specific input format — you freely describe the structure and which bits you want to capture.
+
+For example, suppose you
 have a string that holds some user data that you want to parse into an array of `User`s:
 
 ```swift
@@ -29,8 +36,7 @@ struct User {
 }
 ```
 
-A parser can be constructed for transforming the input string into an array of users in succinct
-and fluent API:
+Construct a parser capturing the sequence of an `Int`, comma, `String`, comma, and a `Bool` into the `User` structure and wrap it in a `Many` to parse the complete list:
 
 ```swift
 let user = Parse(User.init) {
@@ -52,48 +58,33 @@ let users = Many {
 try users.parse(input)  // [User(id: 1, name: "Blob", isAdmin: true), ...]
 ```
 
-This says that to parse a user we:
-
-* Parse and consume an integer from the beginning of the input
-* then a comma
-* then everything up to the next comma
-* then another comma
-* and finally a boolean.
-
-And to parse an entire array of users we:
-
-* Run the `user` parser many times
-* between each invocation of `user` we run the separator parser to consume a newline
-* and once the `user` and separator parsers have consumed all they can we run the terminator
-parser to verify there is no more input to consume.
-
-Further, if the input is malformed, like say we mistyped one of the booleans, then the parser emits
-an error that describes exactly what went wrong:
-
-```swift
-var input = """
-1,Blob,true
-2,Blob Jr.,false
-3,Blob Sr.,tru
-"""
-
-try users.parse(input)
-
-// error: unexpected input
-//  --> input:3:11
-// 3 | 3,Blob Jr,tru
-//   |           ^ expected "true" or "false"
-```
-
-That's the basics of parsing a simple string format, but there are a lot more operators and tricks
-to learn in order to performantly parse larger inputs.
-
 ## Topics
 
-### Articles
+### Parsing
+
+Combine a mix of data and logic parsers to describe the source data format and parse it into useful data structures.
 
 * <doc:GettingStarted>
+* <doc:ParsingData>
+* <doc:ParsingLogic>
+* <doc:Functional>
+* ``Parser``
+
+### Diving Deeper
+
+Learn about the library design and deeper topics like error handling and optimization.  
+
 * <doc:Design>
 * <doc:StringAbstractions>
 * <doc:ErrorMessages>
 * <doc:Backtracking>
+
+### Further Parsers
+
+* ``Parsers``
+
+## See Also
+
+The collecton of videos from Point-Free that dive deep into the development of the Parsing library.
+
+* [Parsing Point-Free Videos](https://www.pointfree.co/collections/parsing)


### PR DESCRIPTION
It's exciting to see you use DocC to create cool documentation for this library. The current state of the documentation on "main" is mostly using the default curation grouping APIs by their type (enumeration, functions, etc.) — I tried to clean up the main page a bit and add grouping that would help developers discover the APIs more easily.

This is an umbrella PR of a bunch of changes done according to the guidelines in https://github.com/apple/swift-docc/tree/main/Sources/DocCDocumentation/DocCDocumentation.docc, https://github.com/apple/swift-docc/blob/main/Sources/DocCDocumentation/DocCDocumentation.docc/adding-structure-to-your-documentation-pages.md specifically but also the rest.

I haven't used `Parsing` extensively so I expect I mis-filed a bunch of APIs so I'm looking forward to your feedback and doing iterations over the current changes.