### PR TITLE
Move OneOfs and Zips to builder namespaces.

### DIFF
--- a/Sources/Parsing/Builders/Variadics.swift
+++ b/Sources/Parsing/Builders/Variadics.swift
@@ -1,6 +1,6 @@
 // BEGIN AUTO-GENERATED CONTENT
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOO<P0: Parser, P1: Parser>: Parser
   where
     P0.Input == P1.Input
@@ -28,12 +28,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1>(
     _ p0: P0, _ p1: P1
-  ) -> Parsers.ZipOO<P0, P1> {
-    Parsers.ZipOO(p0, p1)
+  ) -> ParserBuilder.ZipOO<P0, P1> {
+    ParserBuilder.ZipOO(p0, p1)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOV<P0: Parser, P1: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -59,12 +59,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1>(
     _ p0: P0, _ p1: P1
-  ) -> Parsers.ZipOV<P0, P1> {
-    Parsers.ZipOV(p0, p1)
+  ) -> ParserBuilder.ZipOV<P0, P1> {
+    ParserBuilder.ZipOV(p0, p1)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVO<P0: Parser, P1: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -90,12 +90,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1>(
     _ p0: P0, _ p1: P1
-  ) -> Parsers.ZipVO<P0, P1> {
-    Parsers.ZipVO(p0, p1)
+  ) -> ParserBuilder.ZipVO<P0, P1> {
+    ParserBuilder.ZipVO(p0, p1)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVV<P0: Parser, P1: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -121,12 +121,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1>(
     _ p0: P0, _ p1: P1
-  ) -> Parsers.ZipVV<P0, P1> {
-    Parsers.ZipVV(p0, p1)
+  ) -> ParserBuilder.ZipVV<P0, P1> {
+    ParserBuilder.ZipVV(p0, p1)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOO<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -158,12 +158,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.ZipOOO<P0, P1, P2> {
-    Parsers.ZipOOO(p0, p1, p2)
+  ) -> ParserBuilder.ZipOOO<P0, P1, P2> {
+    ParserBuilder.ZipOOO(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOV<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -195,12 +195,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.ZipOOV<P0, P1, P2> {
-    Parsers.ZipOOV(p0, p1, p2)
+  ) -> ParserBuilder.ZipOOV<P0, P1, P2> {
+    ParserBuilder.ZipOOV(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVO<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -232,12 +232,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.ZipOVO<P0, P1, P2> {
-    Parsers.ZipOVO(p0, p1, p2)
+  ) -> ParserBuilder.ZipOVO<P0, P1, P2> {
+    ParserBuilder.ZipOVO(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVV<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -267,12 +267,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.ZipOVV<P0, P1, P2> {
-    Parsers.ZipOVV(p0, p1, p2)
+  ) -> ParserBuilder.ZipOVV<P0, P1, P2> {
+    ParserBuilder.ZipOVV(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOO<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -304,12 +304,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.ZipVOO<P0, P1, P2> {
-    Parsers.ZipVOO(p0, p1, p2)
+  ) -> ParserBuilder.ZipVOO<P0, P1, P2> {
+    ParserBuilder.ZipVOO(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOV<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -339,12 +339,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.ZipVOV<P0, P1, P2> {
-    Parsers.ZipVOV(p0, p1, p2)
+  ) -> ParserBuilder.ZipVOV<P0, P1, P2> {
+    ParserBuilder.ZipVOV(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVO<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -374,12 +374,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.ZipVVO<P0, P1, P2> {
-    Parsers.ZipVVO(p0, p1, p2)
+  ) -> ParserBuilder.ZipVVO<P0, P1, P2> {
+    ParserBuilder.ZipVVO(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVV<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -409,12 +409,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.ZipVVV<P0, P1, P2> {
-    Parsers.ZipVVV(p0, p1, p2)
+  ) -> ParserBuilder.ZipVVV<P0, P1, P2> {
+    ParserBuilder.ZipVVV(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -450,12 +450,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipOOOO<P0, P1, P2, P3> {
-    Parsers.ZipOOOO(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipOOOO<P0, P1, P2, P3> {
+    ParserBuilder.ZipOOOO(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -491,12 +491,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipOOOV<P0, P1, P2, P3> {
-    Parsers.ZipOOOV(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipOOOV<P0, P1, P2, P3> {
+    ParserBuilder.ZipOOOV(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -532,12 +532,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipOOVO<P0, P1, P2, P3> {
-    Parsers.ZipOOVO(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipOOVO<P0, P1, P2, P3> {
+    ParserBuilder.ZipOOVO(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -573,12 +573,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipOOVV<P0, P1, P2, P3> {
-    Parsers.ZipOOVV(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipOOVV<P0, P1, P2, P3> {
+    ParserBuilder.ZipOOVV(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -614,12 +614,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipOVOO<P0, P1, P2, P3> {
-    Parsers.ZipOVOO(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipOVOO<P0, P1, P2, P3> {
+    ParserBuilder.ZipOVOO(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -655,12 +655,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipOVOV<P0, P1, P2, P3> {
-    Parsers.ZipOVOV(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipOVOV<P0, P1, P2, P3> {
+    ParserBuilder.ZipOVOV(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -696,12 +696,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipOVVO<P0, P1, P2, P3> {
-    Parsers.ZipOVVO(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipOVVO<P0, P1, P2, P3> {
+    ParserBuilder.ZipOVVO(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -735,12 +735,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipOVVV<P0, P1, P2, P3> {
-    Parsers.ZipOVVV(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipOVVV<P0, P1, P2, P3> {
+    ParserBuilder.ZipOVVV(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -776,12 +776,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipVOOO<P0, P1, P2, P3> {
-    Parsers.ZipVOOO(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipVOOO<P0, P1, P2, P3> {
+    ParserBuilder.ZipVOOO(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -817,12 +817,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipVOOV<P0, P1, P2, P3> {
-    Parsers.ZipVOOV(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipVOOV<P0, P1, P2, P3> {
+    ParserBuilder.ZipVOOV(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -858,12 +858,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipVOVO<P0, P1, P2, P3> {
-    Parsers.ZipVOVO(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipVOVO<P0, P1, P2, P3> {
+    ParserBuilder.ZipVOVO(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -897,12 +897,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipVOVV<P0, P1, P2, P3> {
-    Parsers.ZipVOVV(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipVOVV<P0, P1, P2, P3> {
+    ParserBuilder.ZipVOVV(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -938,12 +938,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipVVOO<P0, P1, P2, P3> {
-    Parsers.ZipVVOO(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipVVOO<P0, P1, P2, P3> {
+    ParserBuilder.ZipVVOO(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -977,12 +977,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipVVOV<P0, P1, P2, P3> {
-    Parsers.ZipVVOV(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipVVOV<P0, P1, P2, P3> {
+    ParserBuilder.ZipVVOV(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1016,12 +1016,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipVVVO<P0, P1, P2, P3> {
-    Parsers.ZipVVVO(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipVVVO<P0, P1, P2, P3> {
+    ParserBuilder.ZipVVVO(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1055,12 +1055,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.ZipVVVV<P0, P1, P2, P3> {
-    Parsers.ZipVVVV(p0, p1, p2, p3)
+  ) -> ParserBuilder.ZipVVVV<P0, P1, P2, P3> {
+    ParserBuilder.ZipVVVV(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1100,12 +1100,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOOOOO<P0, P1, P2, P3, P4> {
-    Parsers.ZipOOOOO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOOOOO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOOOOO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1145,12 +1145,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOOOOV<P0, P1, P2, P3, P4> {
-    Parsers.ZipOOOOV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOOOOV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOOOOV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1190,12 +1190,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOOOVO<P0, P1, P2, P3, P4> {
-    Parsers.ZipOOOVO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOOOVO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOOOVO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1235,12 +1235,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOOOVV<P0, P1, P2, P3, P4> {
-    Parsers.ZipOOOVV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOOOVV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOOOVV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1280,12 +1280,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOOVOO<P0, P1, P2, P3, P4> {
-    Parsers.ZipOOVOO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOOVOO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOOVOO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1325,12 +1325,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOOVOV<P0, P1, P2, P3, P4> {
-    Parsers.ZipOOVOV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOOVOV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOOVOV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1370,12 +1370,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOOVVO<P0, P1, P2, P3, P4> {
-    Parsers.ZipOOVVO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOOVVO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOOVVO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1415,12 +1415,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOOVVV<P0, P1, P2, P3, P4> {
-    Parsers.ZipOOVVV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOOVVV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOOVVV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1460,12 +1460,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOVOOO<P0, P1, P2, P3, P4> {
-    Parsers.ZipOVOOO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOVOOO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOVOOO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1505,12 +1505,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOVOOV<P0, P1, P2, P3, P4> {
-    Parsers.ZipOVOOV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOVOOV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOVOOV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1550,12 +1550,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOVOVO<P0, P1, P2, P3, P4> {
-    Parsers.ZipOVOVO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOVOVO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOVOVO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1595,12 +1595,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOVOVV<P0, P1, P2, P3, P4> {
-    Parsers.ZipOVOVV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOVOVV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOVOVV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1640,12 +1640,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOVVOO<P0, P1, P2, P3, P4> {
-    Parsers.ZipOVVOO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOVVOO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOVVOO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1685,12 +1685,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOVVOV<P0, P1, P2, P3, P4> {
-    Parsers.ZipOVVOV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOVVOV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOVVOV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1730,12 +1730,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOVVVO<P0, P1, P2, P3, P4> {
-    Parsers.ZipOVVVO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOVVVO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOVVVO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipOVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1773,12 +1773,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipOVVVV<P0, P1, P2, P3, P4> {
-    Parsers.ZipOVVVV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipOVVVV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipOVVVV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1818,12 +1818,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVOOOO<P0, P1, P2, P3, P4> {
-    Parsers.ZipVOOOO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVOOOO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVOOOO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1863,12 +1863,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVOOOV<P0, P1, P2, P3, P4> {
-    Parsers.ZipVOOOV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVOOOV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVOOOV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1908,12 +1908,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVOOVO<P0, P1, P2, P3, P4> {
-    Parsers.ZipVOOVO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVOOVO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVOOVO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1953,12 +1953,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVOOVV<P0, P1, P2, P3, P4> {
-    Parsers.ZipVOOVV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVOOVV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVOOVV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -1998,12 +1998,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVOVOO<P0, P1, P2, P3, P4> {
-    Parsers.ZipVOVOO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVOVOO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVOVOO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2043,12 +2043,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVOVOV<P0, P1, P2, P3, P4> {
-    Parsers.ZipVOVOV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVOVOV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVOVOV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2088,12 +2088,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVOVVO<P0, P1, P2, P3, P4> {
-    Parsers.ZipVOVVO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVOVVO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVOVVO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2131,12 +2131,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVOVVV<P0, P1, P2, P3, P4> {
-    Parsers.ZipVOVVV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVOVVV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVOVVV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2176,12 +2176,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVVOOO<P0, P1, P2, P3, P4> {
-    Parsers.ZipVVOOO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVVOOO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVVOOO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2221,12 +2221,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVVOOV<P0, P1, P2, P3, P4> {
-    Parsers.ZipVVOOV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVVOOV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVVOOV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2266,12 +2266,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVVOVO<P0, P1, P2, P3, P4> {
-    Parsers.ZipVVOVO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVVOVO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVVOVO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2309,12 +2309,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVVOVV<P0, P1, P2, P3, P4> {
-    Parsers.ZipVVOVV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVVOVV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVVOVV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2354,12 +2354,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVVVOO<P0, P1, P2, P3, P4> {
-    Parsers.ZipVVVOO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVVVOO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVVVOO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2397,12 +2397,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVVVOV<P0, P1, P2, P3, P4> {
-    Parsers.ZipVVVOV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVVVOV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVVVOV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2440,12 +2440,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVVVVO<P0, P1, P2, P3, P4> {
-    Parsers.ZipVVVVO(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVVVVO<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVVVVO(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
+extension ParserBuilder {
   public struct ZipVVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -2483,14 +2483,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.ZipVVVVV<P0, P1, P2, P3, P4> {
-    Parsers.ZipVVVVV(p0, p1, p2, p3, p4)
+  ) -> ParserBuilder.ZipVVVVV<P0, P1, P2, P3, P4> {
+    ParserBuilder.ZipVVVVV(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
-  public struct ZipOOOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2533,14 +2532,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOOOOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOOOOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOOOOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOOOOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2583,14 +2581,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOOOOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOOOOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOOOOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOOOOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2633,14 +2630,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOOOVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOOOVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOOOVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOOOVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2683,14 +2679,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOOOVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOOOVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOOOVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOOOVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2733,14 +2728,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOOVOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOOVOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOOVOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOOVOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2783,14 +2777,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOOVOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOOVOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOOVOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOOVOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2833,14 +2826,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOOVVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOOVVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOOVVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOOVVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2883,14 +2875,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOOVVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOOVVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOOVVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOOVVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2933,14 +2924,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOVOOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOVOOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOVOOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOVOOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -2983,14 +2973,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOVOOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOVOOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOVOOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOVOOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3033,14 +3022,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOVOVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOVOVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOVOVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOVOVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3083,14 +3071,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOVOVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOVOVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOVOVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOVOVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3133,14 +3120,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOVVOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOVVOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOVVOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOVVOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3183,14 +3169,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOVVOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOVVOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOVVOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOVVOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3233,14 +3218,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOVVVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOVVVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOVVVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOVVVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOOVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOOVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3283,14 +3267,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOOVVVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOOVVVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOOVVVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOOVVVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3333,14 +3316,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVOOOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVOOOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVOOOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVOOOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3383,14 +3365,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVOOOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVOOOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVOOOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVOOOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3433,14 +3414,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVOOVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVOOVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVOOVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVOOVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3483,14 +3463,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVOOVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVOOVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVOOVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVOOVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3533,14 +3512,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVOVOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVOVOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVOVOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVOVOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3583,14 +3561,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVOVOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVOVOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVOVOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVOVOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3633,14 +3610,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVOVVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVOVVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVOVVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVOVVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3683,14 +3659,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVOVVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVOVVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVOVVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVOVVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3733,14 +3708,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVVOOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVVOOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVVOOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVVOOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3783,14 +3757,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVVOOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVVOOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVVOOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVVOOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3833,14 +3806,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVVOVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVVOVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVVOVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVVOVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3883,14 +3855,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVVOVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVVOVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVVOVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVVOVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3933,14 +3904,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVVVOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVVVOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVVVOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVVVOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -3983,14 +3953,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVVVOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVVVOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVVVOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVVVOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4033,14 +4002,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVVVVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVVVVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVVVVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVVVVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipOVVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipOVVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4081,14 +4049,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipOVVVVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipOVVVVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipOVVVVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipOVVVVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4131,14 +4098,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOOOOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOOOOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOOOOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOOOOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4181,14 +4147,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOOOOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOOOOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOOOOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOOOOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4231,14 +4196,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOOOVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOOOVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOOOVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOOOVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4281,14 +4245,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOOOVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOOOVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOOOVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOOOVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4331,14 +4294,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOOVOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOOVOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOOVOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOOVOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4381,14 +4343,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOOVOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOOVOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOOVOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOOVOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4431,14 +4392,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOOVVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOOVVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOOVVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOOVVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4481,14 +4441,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOOVVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOOVVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOOVVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOOVVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4531,14 +4490,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOVOOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOVOOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOVOOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOVOOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4581,14 +4539,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOVOOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOVOOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOVOOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOVOOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4631,14 +4588,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOVOVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOVOVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOVOVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOVOVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4681,14 +4637,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOVOVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOVOVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOVOVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOVOVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4731,14 +4686,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOVVOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOVVOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOVVOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOVVOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4781,14 +4735,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOVVOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOVVOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOVVOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOVVOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4831,14 +4784,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOVVVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOVVVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOVVVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOVVVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVOVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVOVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4879,14 +4831,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVOVVVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVOVVVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVOVVVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVOVVVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVOOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4929,14 +4880,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVOOOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVOOOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVOOOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVOOOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVOOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -4979,14 +4929,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVOOOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVOOOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVOOOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVOOOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVOOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5029,14 +4978,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVOOVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVOOVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVOOVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVOOVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVOOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5079,14 +5027,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVOOVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVOOVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVOOVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVOOVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVOVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5129,14 +5076,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVOVOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVOVOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVOVOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVOVOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVOVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5179,14 +5125,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVOVOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVOVOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVOVOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVOVOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVOVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5229,14 +5174,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVOVVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVOVVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVOVVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVOVVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVOVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5277,14 +5221,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVOVVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVOVVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVOVVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVOVVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVVOOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5327,14 +5270,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVVOOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVVOOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVVOOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVVOOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVVOOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5377,14 +5319,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVVOOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVVOOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVVOOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVVOOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVVOVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5427,14 +5368,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVVOVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVVOVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVVOVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVVOVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVVOVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5475,14 +5415,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVVOVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVVOVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVVOVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVVOVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVVVOO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5525,14 +5464,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVVVOO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVVVOO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVVVOO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVVVOO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVVVOV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5573,14 +5511,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVVVOV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVVVOV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVVVOV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVVVOV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVVVVO<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5621,14 +5558,13 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVVVVO<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVVVVO(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVVVVO<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVVVVO(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct ZipVVVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension ParserBuilder {
+  public struct ZipVVVVVV<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5669,12 +5605,12 @@ extension Parsers {
 extension ParserBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.ZipVVVVVV<P0, P1, P2, P3, P4, P5> {
-    Parsers.ZipVVVVVV(p0, p1, p2, p3, p4, p5)
+  ) -> ParserBuilder.ZipVVVVVV<P0, P1, P2, P3, P4, P5> {
+    ParserBuilder.ZipVVVVVV(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
+extension OneOfBuilder {
   public struct OneOf2<P0: Parser, P1: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -5690,10 +5626,7 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
           throw ParsingError.manyFailed(
             [e0, e1], at: input
           )
@@ -5706,12 +5639,12 @@ extension Parsers {
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1>(
     _ p0: P0, _ p1: P1
-  ) -> Parsers.OneOf2<P0, P1> {
-    Parsers.OneOf2(p0, p1)
+  ) -> OneOfBuilder.OneOf2<P0, P1> {
+    OneOfBuilder.OneOf2(p0, p1)
   }
 }
 
-extension Parsers {
+extension OneOfBuilder {
   public struct OneOf3<P0: Parser, P1: Parser, P2: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -5730,14 +5663,8 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
-          do {
-            input = original
-            return try self.p2.parse(&input)
-          } catch let e2 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
+          do { input = original; return try self.p2.parse(&input) } catch let e2 {
             throw ParsingError.manyFailed(
               [e0, e1, e2], at: input
             )
@@ -5751,12 +5678,12 @@ extension Parsers {
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1, P2>(
     _ p0: P0, _ p1: P1, _ p2: P2
-  ) -> Parsers.OneOf3<P0, P1, P2> {
-    Parsers.OneOf3(p0, p1, p2)
+  ) -> OneOfBuilder.OneOf3<P0, P1, P2> {
+    OneOfBuilder.OneOf3(p0, p1, p2)
   }
 }
 
-extension Parsers {
+extension OneOfBuilder {
   public struct OneOf4<P0: Parser, P1: Parser, P2: Parser, P3: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -5778,18 +5705,9 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
-          do {
-            input = original
-            return try self.p2.parse(&input)
-          } catch let e2 {
-            do {
-              input = original
-              return try self.p3.parse(&input)
-            } catch let e3 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
+          do { input = original; return try self.p2.parse(&input) } catch let e2 {
+            do { input = original; return try self.p3.parse(&input) } catch let e3 {
               throw ParsingError.manyFailed(
                 [e0, e1, e2, e3], at: input
               )
@@ -5804,12 +5722,12 @@ extension Parsers {
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3
-  ) -> Parsers.OneOf4<P0, P1, P2, P3> {
-    Parsers.OneOf4(p0, p1, p2, p3)
+  ) -> OneOfBuilder.OneOf4<P0, P1, P2, P3> {
+    OneOfBuilder.OneOf4(p0, p1, p2, p3)
   }
 }
 
-extension Parsers {
+extension OneOfBuilder {
   public struct OneOf5<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser>: Parser
   where
     P0.Input == P1.Input,
@@ -5834,22 +5752,10 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
-          do {
-            input = original
-            return try self.p2.parse(&input)
-          } catch let e2 {
-            do {
-              input = original
-              return try self.p3.parse(&input)
-            } catch let e3 {
-              do {
-                input = original
-                return try self.p4.parse(&input)
-              } catch let e4 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
+          do { input = original; return try self.p2.parse(&input) } catch let e2 {
+            do { input = original; return try self.p3.parse(&input) } catch let e3 {
+              do { input = original; return try self.p4.parse(&input) } catch let e4 {
                 throw ParsingError.manyFailed(
                   [e0, e1, e2, e3, e4], at: input
                 )
@@ -5865,14 +5771,13 @@ extension Parsers {
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4
-  ) -> Parsers.OneOf5<P0, P1, P2, P3, P4> {
-    Parsers.OneOf5(p0, p1, p2, p3, p4)
+  ) -> OneOfBuilder.OneOf5<P0, P1, P2, P3, P4> {
+    OneOfBuilder.OneOf5(p0, p1, p2, p3, p4)
   }
 }
 
-extension Parsers {
-  public struct OneOf6<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>:
-    Parser
+extension OneOfBuilder {
+  public struct OneOf6<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5899,26 +5804,11 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
-          do {
-            input = original
-            return try self.p2.parse(&input)
-          } catch let e2 {
-            do {
-              input = original
-              return try self.p3.parse(&input)
-            } catch let e3 {
-              do {
-                input = original
-                return try self.p4.parse(&input)
-              } catch let e4 {
-                do {
-                  input = original
-                  return try self.p5.parse(&input)
-                } catch let e5 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
+          do { input = original; return try self.p2.parse(&input) } catch let e2 {
+            do { input = original; return try self.p3.parse(&input) } catch let e3 {
+              do { input = original; return try self.p4.parse(&input) } catch let e4 {
+                do { input = original; return try self.p5.parse(&input) } catch let e5 {
                   throw ParsingError.manyFailed(
                     [e0, e1, e2, e3, e4, e5], at: input
                   )
@@ -5935,15 +5825,13 @@ extension Parsers {
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5
-  ) -> Parsers.OneOf6<P0, P1, P2, P3, P4, P5> {
-    Parsers.OneOf6(p0, p1, p2, p3, p4, p5)
+  ) -> OneOfBuilder.OneOf6<P0, P1, P2, P3, P4, P5> {
+    OneOfBuilder.OneOf6(p0, p1, p2, p3, p4, p5)
   }
 }
 
-extension Parsers {
-  public struct OneOf7<
-    P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser, P6: Parser
-  >: Parser
+extension OneOfBuilder {
+  public struct OneOf7<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser, P6: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -5973,30 +5861,12 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
-          do {
-            input = original
-            return try self.p2.parse(&input)
-          } catch let e2 {
-            do {
-              input = original
-              return try self.p3.parse(&input)
-            } catch let e3 {
-              do {
-                input = original
-                return try self.p4.parse(&input)
-              } catch let e4 {
-                do {
-                  input = original
-                  return try self.p5.parse(&input)
-                } catch let e5 {
-                  do {
-                    input = original
-                    return try self.p6.parse(&input)
-                  } catch let e6 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
+          do { input = original; return try self.p2.parse(&input) } catch let e2 {
+            do { input = original; return try self.p3.parse(&input) } catch let e3 {
+              do { input = original; return try self.p4.parse(&input) } catch let e4 {
+                do { input = original; return try self.p5.parse(&input) } catch let e5 {
+                  do { input = original; return try self.p6.parse(&input) } catch let e6 {
                     throw ParsingError.manyFailed(
                       [e0, e1, e2, e3, e4, e5, e6], at: input
                     )
@@ -6014,15 +5884,13 @@ extension Parsers {
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5, P6>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6
-  ) -> Parsers.OneOf7<P0, P1, P2, P3, P4, P5, P6> {
-    Parsers.OneOf7(p0, p1, p2, p3, p4, p5, p6)
+  ) -> OneOfBuilder.OneOf7<P0, P1, P2, P3, P4, P5, P6> {
+    OneOfBuilder.OneOf7(p0, p1, p2, p3, p4, p5, p6)
   }
 }
 
-extension Parsers {
-  public struct OneOf8<
-    P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser, P6: Parser, P7: Parser
-  >: Parser
+extension OneOfBuilder {
+  public struct OneOf8<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser, P6: Parser, P7: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -6041,9 +5909,7 @@ extension Parsers {
   {
     public let p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7
 
-    @inlinable public init(
-      _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7
-    ) {
+    @inlinable public init(_ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7) {
       self.p0 = p0
       self.p1 = p1
       self.p2 = p2
@@ -6057,34 +5923,13 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
-          do {
-            input = original
-            return try self.p2.parse(&input)
-          } catch let e2 {
-            do {
-              input = original
-              return try self.p3.parse(&input)
-            } catch let e3 {
-              do {
-                input = original
-                return try self.p4.parse(&input)
-              } catch let e4 {
-                do {
-                  input = original
-                  return try self.p5.parse(&input)
-                } catch let e5 {
-                  do {
-                    input = original
-                    return try self.p6.parse(&input)
-                  } catch let e6 {
-                    do {
-                      input = original
-                      return try self.p7.parse(&input)
-                    } catch let e7 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
+          do { input = original; return try self.p2.parse(&input) } catch let e2 {
+            do { input = original; return try self.p3.parse(&input) } catch let e3 {
+              do { input = original; return try self.p4.parse(&input) } catch let e4 {
+                do { input = original; return try self.p5.parse(&input) } catch let e5 {
+                  do { input = original; return try self.p6.parse(&input) } catch let e6 {
+                    do { input = original; return try self.p7.parse(&input) } catch let e7 {
                       throw ParsingError.manyFailed(
                         [e0, e1, e2, e3, e4, e5, e6, e7], at: input
                       )
@@ -6103,16 +5948,13 @@ extension Parsers {
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5, P6, P7>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7
-  ) -> Parsers.OneOf8<P0, P1, P2, P3, P4, P5, P6, P7> {
-    Parsers.OneOf8(p0, p1, p2, p3, p4, p5, p6, p7)
+  ) -> OneOfBuilder.OneOf8<P0, P1, P2, P3, P4, P5, P6, P7> {
+    OneOfBuilder.OneOf8(p0, p1, p2, p3, p4, p5, p6, p7)
   }
 }
 
-extension Parsers {
-  public struct OneOf9<
-    P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser, P6: Parser, P7: Parser,
-    P8: Parser
-  >: Parser
+extension OneOfBuilder {
+  public struct OneOf9<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser, P6: Parser, P7: Parser, P8: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -6133,9 +5975,7 @@ extension Parsers {
   {
     public let p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8
 
-    @inlinable public init(
-      _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7, _ p8: P8
-    ) {
+    @inlinable public init(_ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7, _ p8: P8) {
       self.p0 = p0
       self.p1 = p1
       self.p2 = p2
@@ -6150,38 +5990,14 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
-          do {
-            input = original
-            return try self.p2.parse(&input)
-          } catch let e2 {
-            do {
-              input = original
-              return try self.p3.parse(&input)
-            } catch let e3 {
-              do {
-                input = original
-                return try self.p4.parse(&input)
-              } catch let e4 {
-                do {
-                  input = original
-                  return try self.p5.parse(&input)
-                } catch let e5 {
-                  do {
-                    input = original
-                    return try self.p6.parse(&input)
-                  } catch let e6 {
-                    do {
-                      input = original
-                      return try self.p7.parse(&input)
-                    } catch let e7 {
-                      do {
-                        input = original
-                        return try self.p8.parse(&input)
-                      } catch let e8 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
+          do { input = original; return try self.p2.parse(&input) } catch let e2 {
+            do { input = original; return try self.p3.parse(&input) } catch let e3 {
+              do { input = original; return try self.p4.parse(&input) } catch let e4 {
+                do { input = original; return try self.p5.parse(&input) } catch let e5 {
+                  do { input = original; return try self.p6.parse(&input) } catch let e6 {
+                    do { input = original; return try self.p7.parse(&input) } catch let e7 {
+                      do { input = original; return try self.p8.parse(&input) } catch let e8 {
                         throw ParsingError.manyFailed(
                           [e0, e1, e2, e3, e4, e5, e6, e7, e8], at: input
                         )
@@ -6201,16 +6017,13 @@ extension Parsers {
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5, P6, P7, P8>(
     _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7, _ p8: P8
-  ) -> Parsers.OneOf9<P0, P1, P2, P3, P4, P5, P6, P7, P8> {
-    Parsers.OneOf9(p0, p1, p2, p3, p4, p5, p6, p7, p8)
+  ) -> OneOfBuilder.OneOf9<P0, P1, P2, P3, P4, P5, P6, P7, P8> {
+    OneOfBuilder.OneOf9(p0, p1, p2, p3, p4, p5, p6, p7, p8)
   }
 }
 
-extension Parsers {
-  public struct OneOf10<
-    P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser, P6: Parser, P7: Parser,
-    P8: Parser, P9: Parser
-  >: Parser
+extension OneOfBuilder {
+  public struct OneOf10<P0: Parser, P1: Parser, P2: Parser, P3: Parser, P4: Parser, P5: Parser, P6: Parser, P7: Parser, P8: Parser, P9: Parser>: Parser
   where
     P0.Input == P1.Input,
     P1.Input == P2.Input,
@@ -6233,10 +6046,7 @@ extension Parsers {
   {
     public let p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9
 
-    @inlinable public init(
-      _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7, _ p8: P8,
-      _ p9: P9
-    ) {
+    @inlinable public init(_ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7, _ p8: P8, _ p9: P9) {
       self.p0 = p0
       self.p1 = p1
       self.p2 = p2
@@ -6252,42 +6062,15 @@ extension Parsers {
     @inlinable public func parse(_ input: inout P0.Input) rethrows -> P0.Output {
       let original = input
       do { return try self.p0.parse(&input) } catch let e0 {
-        do {
-          input = original
-          return try self.p1.parse(&input)
-        } catch let e1 {
-          do {
-            input = original
-            return try self.p2.parse(&input)
-          } catch let e2 {
-            do {
-              input = original
-              return try self.p3.parse(&input)
-            } catch let e3 {
-              do {
-                input = original
-                return try self.p4.parse(&input)
-              } catch let e4 {
-                do {
-                  input = original
-                  return try self.p5.parse(&input)
-                } catch let e5 {
-                  do {
-                    input = original
-                    return try self.p6.parse(&input)
-                  } catch let e6 {
-                    do {
-                      input = original
-                      return try self.p7.parse(&input)
-                    } catch let e7 {
-                      do {
-                        input = original
-                        return try self.p8.parse(&input)
-                      } catch let e8 {
-                        do {
-                          input = original
-                          return try self.p9.parse(&input)
-                        } catch let e9 {
+        do { input = original; return try self.p1.parse(&input) } catch let e1 {
+          do { input = original; return try self.p2.parse(&input) } catch let e2 {
+            do { input = original; return try self.p3.parse(&input) } catch let e3 {
+              do { input = original; return try self.p4.parse(&input) } catch let e4 {
+                do { input = original; return try self.p5.parse(&input) } catch let e5 {
+                  do { input = original; return try self.p6.parse(&input) } catch let e6 {
+                    do { input = original; return try self.p7.parse(&input) } catch let e7 {
+                      do { input = original; return try self.p8.parse(&input) } catch let e8 {
+                        do { input = original; return try self.p9.parse(&input) } catch let e9 {
                           throw ParsingError.manyFailed(
                             [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], at: input
                           )
@@ -6307,10 +6090,9 @@ extension Parsers {
 
 extension OneOfBuilder {
   @inlinable public static func buildBlock<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(
-    _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7, _ p8: P8,
-    _ p9: P9
-  ) -> Parsers.OneOf10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> {
-    Parsers.OneOf10(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
+    _ p0: P0, _ p1: P1, _ p2: P2, _ p3: P3, _ p4: P4, _ p5: P5, _ p6: P6, _ p7: P7, _ p8: P8, _ p9: P9
+  ) -> OneOfBuilder.OneOf10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> {
+    OneOfBuilder.OneOf10(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
   }
 }
 

--- a/Sources/variadics-generator/VariadicsGenerator.swift
+++ b/Sources/variadics-generator/VariadicsGenerator.swift
@@ -98,7 +98,7 @@ struct VariadicsGenerator: ParsableCommand {
     for permutation in Permutations(arity: arity) {
       // Emit type declaration.
       let typeName = "Zip\(permutation.identifier)"
-      output("extension Parsers {\n  public struct \(typeName)<")
+      output("extension ParserBuilder {\n  public struct \(typeName)<")
       outputForEach(0..<arity, separator: ", ") { "P\($0): Parser" }
       output(">: Parser\n  where\n    ")
       outputForEach(Array(zip(0..<arity, (0..<arity).dropFirst())), separator: ",\n    ") {
@@ -149,10 +149,10 @@ struct VariadicsGenerator: ParsableCommand {
       outputForEach(0..<arity, separator: ", ") { "P\($0)" }
       output(">(\n    ")
       outputForEach(0..<arity, separator: ", ") { "_ p\($0): P\($0)" }
-      output("\n  ) -> Parsers.\(typeName)<")
+      output("\n  ) -> ParserBuilder.\(typeName)<")
       outputForEach(0..<arity, separator: ", ") { "P\($0)" }
       output("> {\n")
-      output("    Parsers.\(typeName)(")
+      output("    ParserBuilder.\(typeName)(")
       outputForEach(0..<arity, separator: ", ") { "p\($0)" }
       output(")\n  }\n}\n\n")
     }
@@ -161,7 +161,7 @@ struct VariadicsGenerator: ParsableCommand {
   func emitOneOfDeclaration(arity: Int) {
     // Emit type declaration.
     let typeName = "OneOf\(arity)"
-    output("extension Parsers {\n  public struct \(typeName)<")
+    output("extension OneOfBuilder {\n  public struct \(typeName)<")
     outputForEach(0..<arity, separator: ", ") { "P\($0): Parser" }
     output(">: Parser\n  where\n    ")
     outputForEach(Array(zip(0..<arity, (0..<arity).dropFirst())), separator: ",\n    ") {
@@ -201,10 +201,10 @@ struct VariadicsGenerator: ParsableCommand {
     outputForEach(0..<arity, separator: ", ") { "P\($0)" }
     output(">(\n    ")
     outputForEach(0..<arity, separator: ", ") { "_ p\($0): P\($0)" }
-    output("\n  ) -> Parsers.\(typeName)<")
+    output("\n  ) -> OneOfBuilder.\(typeName)<")
     outputForEach(0..<arity, separator: ", ") { "P\($0)" }
     output("> {\n")
-    output("    Parsers.\(typeName)(")
+    output("    OneOfBuilder.\(typeName)(")
     outputForEach(0..<arity, separator: ", ") { "p\($0)" }
     output(")\n  }\n}\n\n")
   }


### PR DESCRIPTION
These types are only used for builders (and hopefully they will go away with variadics+[`buildPartialBlock`](https://forums.swift.org/t/pitch-buildpartialblock-for-result-builders/55561)) so better to nest them inside the builder namespaces. Also helps clean up docs a little.