### PR TITLE
[Experimental] Add DelimitedBy (new variant)

### DIFF
--- a/Sources/Parsing/Parsers/DelimitedBy.swift
+++ b/Sources/Parsing/Parsers/DelimitedBy.swift
@@ -1,0 +1,104 @@
+
+  public struct DelimitedBy<Input: Collection>: Parser where Input.SubSequence == Input {
+    public enum Escaping {
+      case escapedBy(Input)
+      case enclosedBetween(Input, Input)
+      @inlinable
+      public static func enclosedBy(_ input: Input) -> Self {
+        .enclosedBetween(input, input)
+      }
+    }
+
+    public let delimiter: Input
+    public let escaping: Escaping?
+    public let areEquivalent: (Input.Element, Input.Element) -> Bool
+
+    @inlinable
+    public init(
+      _ delimiter: Input,
+      _ escaping: Escaping? = nil,
+      areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+    ) {
+      self.delimiter = delimiter
+      self.escaping = escaping
+      self.areEquivalent = areEquivalent
+    }
+
+    @inlinable
+    public func parse(_ input: inout Input) throws -> Input {
+      let original = input
+      let index = try parseUpToNextDelimiter(&input)
+      input = original[index...]
+      return original[..<index]
+    }
+
+    @inlinable
+    func parseUpToNextDelimiter(_ input: inout Input) throws -> Input.Index {
+      let original = input
+      let nextDelimiter: Input
+      do {
+        nextDelimiter = try PrefixUpTo(delimiter, by: areEquivalent).parse(&input)
+      } catch {
+        throw ParsingError.expectedInput("unescaped delimiter", at: input)
+      }
+      // Was this delimiter escaped?
+      guard let escaping = escaping else {
+        return nextDelimiter.endIndex
+      }
+
+      switch escaping {
+      case .escapedBy(let escape):
+        let escapedDelimiter = Parse {
+          PrefixThrough(escape, by: areEquivalent)
+          Peek { StartsWith<Input>(delimiter, by: areEquivalent) }
+        }
+
+        var escapingInput = original
+        while let escaped = try? escapedDelimiter.parse(&escapingInput) {
+          if escaped.endIndex == nextDelimiter.endIndex {
+            // Consume the escaped delimiter
+            try StartsWith(delimiter, by: areEquivalent).parse(&escapingInput)
+            var trimmedInput = original[escapingInput.startIndex...]
+            return try parseUpToNextDelimiter(&trimmedInput)
+          } else if escaped.endIndex > nextDelimiter.endIndex {
+            // nextDelimiter is acceptable
+            break
+          } else {
+            // Consume the escape input
+            try StartsWith(escape, by: areEquivalent).parse(&escapingInput)
+          }
+        }
+        return nextDelimiter.endIndex
+      case .enclosedBetween(let start, let end):
+        let enclosed = Parse {
+          StartsWith<Input>(start, by: areEquivalent)
+          PrefixThrough(end, by: areEquivalent)
+        }
+        var escapingInput = original
+        while let escaped = try? enclosed.parse(&escapingInput) {
+          if escaped.indices.contains(nextDelimiter.endIndex) {
+            // nextDelimiter was enclosed
+            var trimmedInput = original[escaped.endIndex...]
+            return try parseUpToNextDelimiter(&trimmedInput)
+          } else if escaped.startIndex > nextDelimiter.endIndex {
+            // nextDelimiter is acceptable
+            break
+          }
+        }
+        return nextDelimiter.endIndex
+      }
+    }
+  }
+
+
+extension DelimitedBy {
+  @inlinable
+  public init(
+    _ delimiter: Input,
+    _ escaping: Escaping? = nil
+  ) where Input.Element: Equatable {
+    self.delimiter = delimiter
+    self.escaping = escaping
+    self.areEquivalent = (==)
+  }
+}

--- a/Tests/ParsingTests/DelimitedByTests.swift
+++ b/Tests/ParsingTests/DelimitedByTests.swift
@@ -1,0 +1,55 @@
+import Parsing
+import XCTest
+
+final class DelimitedByTests: XCTestCase {
+  func testDelimited() throws {
+    let commaDelimited = DelimitedBy(","[...], .escapedBy("\\"))
+    
+    var input = "1234,567"[...]
+    let parsed = try commaDelimited.parse(&input)
+    XCTAssertEqual(parsed, "1234")
+    XCTAssertEqual(input, ",567")
+  }
+  
+  func testDelimitedEscaped() throws {
+    let commaDelimited = DelimitedBy(","[...], .escapedBy("\\"))
+
+    var input = "1234\\,5\\,67,"[...]
+    var parsed = try commaDelimited.parse(&input)
+    XCTAssertEqual(parsed, "1234\\,5\\,67")
+    XCTAssertEqual(input, ",")
+    
+    input = "67,1234\\,5\\,"[...]
+    parsed = try commaDelimited.parse(&input)
+    XCTAssertEqual(parsed, "67")
+    XCTAssertEqual(input, ",1234\\,5\\,")
+  }
+  
+  func testDelimitedEnclosed() throws {
+    let commaDelimited = DelimitedBy(","[...], .enclosedBy("\""))
+
+    var input = "\"1234,5,\",67"[...]
+    var parsed = try commaDelimited.parse(&input)
+    XCTAssertEqual(parsed, "\"1234,5,\"")
+    XCTAssertEqual(input, ",67")
+    
+    input = "67,\"1234,5,\""[...]
+    parsed = try commaDelimited.parse(&input)
+    XCTAssertEqual(parsed, "67")
+    XCTAssertEqual(input, ",\"1234,5,\"")
+  }
+  
+  func testDelimitedEnclosedWithDifferentBoundaries() throws {
+    let commaDelimited = DelimitedBy(","[...], .enclosedBetween("[", "]"))
+
+    var input = "[1234,5,],67"[...]
+    var parsed = try commaDelimited.parse(&input)
+    XCTAssertEqual(parsed, "[1234,5,]")
+    XCTAssertEqual(input, ",67")
+    
+    input = "67,[1234,5,]"[...]
+    parsed = try commaDelimited.parse(&input)
+    XCTAssertEqual(parsed, "67")
+    XCTAssertEqual(input, ",[1234,5,]")
+  }
+}


### PR DESCRIPTION
This PR is a draft that could hopefully lead to a very exciting feature.
This is a simplified variant of #35. This old PR was trying a whole parser at each element, which was quite inefficient and enough for not being investigated further. It was more general but also had a broader scope, being able to handle nesting of delimiters. 

This parser is much simpler. It parses components separated by a `delimiter: Input` (e.g. `","`), and it is smart enough to bypass delimiters being escaped with a prefix  (e.g. `"\,"`) or enclosed delimiters (e.g. `"[1,2],xxx"`).

This parser is de facto slower than `PrefixUpTo`, because it does more checks:
- It tries to parse up to the delimiter
- If it succeeds, it tries to parse escaping/enclosing sequences from the start until it can decide if the parsed delimiter is receivable
- If it is receivable, the output is returned. Otherwise, it tries again, starting after this bypassed position.

Maybe the `escaping` argument can be forced to be non-nil, and parsing of unescaped delimiters devolved to `PrefixUpTo(delimiter)` (we can communicate this to the user by using an `unavailable` overload when `escaping` is nil if needed). The "escaped" route can probably be improved by parsing back from the parsed delimiter instead of parsing the escaping sequences from the start. This is a draft implementation that seems to work.

### The big picture
This parser may seem redundant with ad-hoc parsers of components, but the endgame would be to build a concurrent `Many` parser of components based on it. A more evolved version of this parser would generate subsequences of input that could be concurrently sent to component parsers. For example, it would concurrently send each line of a CSV file through parsers of CSV entries. For this to work, the parser of lines should be able to make some simple decisions (like bypassing newlines in quoted fields), without parsing the line rigorously with a dedicated parser (which is done asynchronously). `PrefixUpTo` seems too limited for the task in real life. Right now, the parser supports bypassing escaped and enclosed delimiters, but other strategies are probably possible, keeping in mind that its only purpose is slicing pieces of `Input` that will be piped into more complex parsers. I didn't explore which other parsers can support concurrent parsing yet, but this `Many` case seems quite obvious.

So, to sum up, in order to build a concurrent `Many` parser, we need a parser that is capable of quickly slicing the input between separators. `PrefixUpTo` is probably too simple for the task, and this `DelimitedBy` parser is an intermediate solution between `PrefixUpTo` and the fully-fledged component parser that will process the slice concurrently. 
This `DelimitedBy` parser can also help in synchronous contexts.

I didn't have the time to play a lot with throwing parsers, and I don't think that errors are optimal yet, so any suggestion is welcome. There is also no documentation for now.

What do you think about it?