### PR TITLE
Fix some docc and added docs to Not and Peek.

### DIFF
--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/Int.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/Int.md
@@ -51,7 +51,7 @@ try Parse {
   ","
   Int.parser()
 }
-.parse("true,false") // (true, false)
+.parse("123,456") // (123, 456)
 ```
 
 On the other hand, if `Int.parser()` is used in a context where the input type cannot be inferred,

--- a/Sources/Parsing/Parsers/Not.swift
+++ b/Sources/Parsing/Parsers/Not.swift
@@ -1,16 +1,21 @@
 /// A parser that succeeds if the given parser fails, and does not consume any input.
 ///
-/// For example:
+/// For example, to parse a line from an input that does not start with "//" one can do:
 ///
 /// ```swift
 /// let uncommentedLine = Parse {
 ///   Not { "//" }
 ///   PrefixUpTo("\n")
 /// }
-/// ```
 ///
-/// This will check the input doesn't start with `"//"`, and if it doesn't, it will return the whole
-/// input up to the first newline.
+/// try uncommentedLine.parse("let x = 1") // ✅ "let x = 1"
+///
+/// try uncommentedLine.parse("// let x = 1") // ❌
+/// // error: unexpected input
+/// //  --> input:1:1-2
+/// // 1 | // let x = 1
+/// //   | ^^ expected not to be processed
+/// ```
 public struct Not<Upstream: Parser>: Parser {
   public let upstream: Upstream
 

--- a/Sources/Parsing/Parsers/Peek.swift
+++ b/Sources/Parsing/Parsers/Peek.swift
@@ -14,6 +14,14 @@
 ///   Peek { Prefix(1) { $0.isLetter || $0 == "_" } }
 ///   Prefix { $0.isNumber || $0.isLetter || $0 == "_" }
 /// }
+///
+/// try identifier.parse("foo123") // ✅ "foo123"
+/// try identifier.parse("_foo123") // ✅ "_foo123"
+/// try identifier.parse("1_foo123") // ❌
+/// // error: unexpected input
+/// //  --> input:1:1
+/// // 1 | 1_foo123
+/// //   | ^ expected 1 element satisfying predicate
 /// ```
 public struct Peek<Upstream: Parser>: Parser {
   public let upstream: Upstream


### PR DESCRIPTION
A docc fix that @KeithBird pointed out, and also I noticed that we didn't have any actual usage of the `Not` and `Peek` parsers so I added some more to their docs.