### PR TITLE
Fix recently updated docc files & added docs to Not and Peek

### DIFF
--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/Bool.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/Bool.md
@@ -2,7 +2,7 @@
 
 A parser that consumes a Boolean value from the beginning of a string.
 
-This parser only recognizes the literal "true" and "false" sequence of characters:
+This parser only recognizes the literal `"true"` and `"false"` sequence of characters:
 
 ```swift
 // Parses "true":
@@ -31,16 +31,17 @@ UTF-8 code units (see <doc:StringAbstractions> for more info).
 
 Typically Swift can choose the correct overload by using type inference based on what other parsers
 you are combining `Bool.parser()` with. For example, if you use `Bool.parser()` with a
-`Substring` parser, say the literal "," parser (see <doc:String> for more information), Swift
+`Substring` parser, say the literal `","` parser (see <doc:String> for more information), Swift
 will choose the overload that works on substrings:
 
 ```swift
-try Parse {
+let parser = Parse {
   Bool.parser()
   ","
   Bool.parser()
 }
-.parse("true,false") // (true, false)
+
+try parser.parse("true,false") // (true, false)
 ```
 
 On the other hand, if `Bool.parser()` is used in a context where the input type cannot be inferred,
@@ -59,9 +60,10 @@ To fix this you can force one of the boolean parsers to be the `Substring` parse
 other will figure it out via type inference:
 
 ```swift
-try Parse {
+let parser = Parse {
   Bool.parser(of: Substring.self)
-  Bool.parser()
+  Bool.parser() // ✅
 }
-.parse("truefalse") // (true, false)
+
+try parser.parse("truefalse")
 ```

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/CharacterSet.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/CharacterSet.md
@@ -5,7 +5,7 @@ A parser that consumes the characters contained in a `CharacterSet` from the beg
 For example:
 
 ```swift
-try Parse {
+Parse {
   CharacterSet.alphanumerics
   CharacterSet.punctuationCharacters
   CharacterSet.alphanumerics

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/CharacterSet.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/CharacterSet.md
@@ -5,7 +5,7 @@ A parser that consumes the characters contained in a `CharacterSet` from the beg
 For example:
 
 ```swift
-Parse {
+try Parse {
   CharacterSet.alphanumerics
   CharacterSet.punctuationCharacters
   CharacterSet.alphanumerics

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/Double.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/Double.md
@@ -25,36 +25,39 @@ UTF-8 code units (see <doc:StringAbstractions> for more info).
 
 Typically Swift can choose the correct overload by using type inference based on what other parsers
 you are combining `Double.parser()` with. For example, if you use `Double.parser()` with a
-`Substring` parser, say the literal "," parser (see <doc:String> for more information), Swift
+`Substring` parser, say the literal `","` parser (see <doc:String> for more information), Swift
 will choose the overload that works on substrings:
 
 ```swift
-try Parse {
+let parser = Parse {
   Double.parser()
   ","
   Double.parser()
 }
-.parse("1,-2") // (1.0, -2.0)
+
+try parser.parse("1,-2") // (1.0, -2.0)
 ```
 
 On the other hand, if `Double.parser()` is used in a context where the input type cannot be inferred,
 then you will get an compiler error:
 
 ```swift
-try Parse {
+let parser = Parse {
   Double.parser()
   Double.parser() // 🛑 Ambiguous use of 'parser(of:)'
 }
-.parse(".1.2")
+
+try parser.parse(".1.2")
 ```
 
 To fix this you can force one of the double parsers to be the `Substring` parser, and then the
 other will figure it out via type inference:
 
 ```swift
-try Parse {
+let parser = Parse {
   Double.parser(of: Substring.self)
-  Double.parser()
+  Double.parser() // ✅
 }
-.parse(".1.2") // (0.1, 0.2)
+
+try parser.parse(".1.2") // (0.1, 0.2)
 ```

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/Float.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/Float.md
@@ -25,16 +25,17 @@ UTF-8 code units (see <doc:StringAbstractions> for more info).
 
 Typically Swift can choose the correct overload by using type inference based on what other parsers
 you are combining `Float.parser()` with. For example, if you use `Float.parser()` with a
-`Substring` parser, say the literal "," parser (see <doc:String> for more information), Swift
+`Substring` parser, say the literal `","` parser (see <doc:String> for more information), Swift
 will choose the overload that works on substrings:
 
 ```swift
-try Parse {
+let parser = Parse {
   Float.parser()
   ","
   Float.parser()
 }
-.parse("1,-2") // (1.0, -2.0)
+
+try parser.parse("1,-2") // (1.0, -2.0)
 ```
 
 On the other hand, if `Float.parser()` is used in a context where the input type cannot be inferred,
@@ -53,9 +54,10 @@ To fix this you can force one of the float parsers to be the `Substring` parser,
 other will figure it out via type inference:
 
 ```swift
-try Parse {
+let parser = Parse {
   Float.parser(of: Substring.self)
-  Float.parser()
+  Float.parser() // ✅
 }
-.parse(".1.2") // (0.1, 0.2)
+
+try parser.parse(".1.2") // (0.1, 0.2)
 ```

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/Int.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/Int.md
@@ -51,7 +51,7 @@ try Parse {
   ","
   Int.parser()
 }
-.parse("true,false") // (true, false)
+.parse("123,456") // (123, 456)
 ```
 
 On the other hand, if `Int.parser()` is used in a context where the input type cannot be inferred,

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/Int.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/Int.md
@@ -6,11 +6,11 @@ a string.
 ```swift
 var input = "123 Hello world"[...]
 try Int.parser().parse(&input) // 123
-input // " Hello world")
+input // " Hello world"
 
 input = "-123 Hello world"
 try Int.parser().parse(&input) // -123
-input // " Hello world")
+input // " Hello world"
 ```
 
 This parser fails when it does not find an integer at the beginning of the collection:
@@ -42,36 +42,39 @@ UTF-8 code units (see <doc:StringAbstractions> for more info).
 
 Typically Swift can choose the correct overload by using type inference based on what other parsers
 you are combining `Int.parser()` with. For example, if you use `Int.parser()` with a
-`Substring` parser, say the literal "," parser (see <doc:String> for more information), Swift
+`Substring` parser, say the literal `","` parser (see <doc:String> for more information), Swift
 will choose the overload that works on substrings:
 
 ```swift
-try Parse {
+let parser = Parse {
   Int.parser()
   ","
   Int.parser()
 }
-.parse("123,456") // (123, 456)
+
+try parser.parse("123,456") // (123, 456)
 ```
 
 On the other hand, if `Int.parser()` is used in a context where the input type cannot be inferred,
 then you will get an compiler error:
 
 ```swift
-try Parse {
-  Int.parser()
-  Bool.parser() // 🛑 Ambiguous use of 'parser(of:)'
+let parser = Parse {
+  Int.parser() // 🛑 Ambiguous use of 'parser(of:isSigned:radix:)'
+  Bool.parser()
 }
-.parse("123true")
+
+try parser.parse("123true")
 ```
 
-To fix this you can force one of the integer parsers to be the `Substring` parser, and then the
+To fix this you can force one of the parsers to be the `Substring` parser, and then the
 other will figure it out via type inference:
 
 ```swift
-try Parse {
-  Int.parser(of: Substring.self)
-  Bool.parser()
+let parser = Parse {
+  Int.parser() // ✅
+  Bool.parser(of: Substring.self)
 }
-.parse("123true") // (123, true)
+
+try parser.parse("123true") // (123, true) 
 ```

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/String.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/String.md
@@ -14,7 +14,7 @@ try Parse {
 .parse("123,456") // (123, 456)
 ```
 
-The string "," acts as a parser that consumes a comma from the beginning of an input and fails
+The string `","` acts as a parser that consumes a comma from the beginning of an input and fails
 if the input does not start with a comma.
 
 Swift's other string representations also conform to ``Parser``, such as `UnicodeScalarView`

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/UUID.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/UUID.md
@@ -5,10 +5,11 @@ A parser that consumes a `UUID` value from the beginning of a string.
 For example:
 
 ```swift
-Parse {
+try Parse {
   UUID.parser()
   ","
   Bool.parser()
 }
-.parse("deadbeef-dead-beef-dead-beefdeadbeef,true") // (UUID(deadbeef-dead-beef-dead-beefdeadbeef), true)
+.parse("deadbeef-dead-beef-dead-beefdeadbeef,true")
+// (DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF, true)
 ```

--- a/Sources/Parsing/Parsers/Not.swift
+++ b/Sources/Parsing/Parsers/Not.swift
@@ -1,16 +1,21 @@
 /// A parser that succeeds if the given parser fails, and does not consume any input.
 ///
-/// For example:
+/// For example, to parse a line from an input that does not start with "//" one can do:
 ///
 /// ```swift
 /// let uncommentedLine = Parse {
 ///   Not { "//" }
 ///   PrefixUpTo("\n")
 /// }
-/// ```
 ///
-/// This will check the input doesn't start with `"//"`, and if it doesn't, it will return the whole
-/// input up to the first newline.
+/// try uncommentedLine.parse("let x = 1") // ✅ "let x = 1"
+///
+/// try uncommentedLine.parse("// let x = 1") // ❌
+/// // error: unexpected input
+/// //  --> input:1:1-2
+/// // 1 | // let x = 1
+/// //   | ^^ expected not to be processed
+/// ```
 public struct Not<Upstream: Parser>: Parser {
   public let upstream: Upstream
 

--- a/Sources/Parsing/Parsers/Peek.swift
+++ b/Sources/Parsing/Parsers/Peek.swift
@@ -14,6 +14,14 @@
 ///   Peek { Prefix(1) { $0.isLetter || $0 == "_" } }
 ///   Prefix { $0.isNumber || $0.isLetter || $0 == "_" }
 /// }
+///
+/// try identifier.parse("foo123") // ✅ "foo123"
+/// try identifier.parse("_foo123") // ✅ "_foo123"
+/// try identifier.parse("1_foo123") // ❌
+/// // error: unexpected input
+/// //  --> input:1:1
+/// // 1 | 1_foo123
+/// //   | ^ expected 1 element satisfying predicate
 /// ```
 public struct Peek<Upstream: Parser>: Parser {
   public let upstream: Upstream


### PR DESCRIPTION
Previous this kind of code can be compiled (while the original intention is not so), because Xcode can infer that the type is `Substring` by `.parse(".1.2")`.

```swift
try Parse {
  Double.parser()
  Double.parser() // 🛑 Ambiguous use of 'parser(of:)'
}
.parse(".1.2")
```

We can fix it like this:

```swift
let parser = Parse {
  Double.parser()
  Double.parser() // 🛑 Ambiguous use of 'parser(of:)'
}

try parser.parse(".1.2")
```