### PR TITLE
Remove `isSigned` config from `Int.parser()`

### DIFF
--- a/Sources/Parsing/Documentation.docc/Articles/Design.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Design.md
@@ -79,13 +79,13 @@ to maximize readability of the parsers. For example, to parse accounting syntax 
 parenthesized numbers are negative, we can use the ``OneOf`` parser builder:
 
 ```swift
+let digits = Prefix { $0.isNumber }.compactMap(Int.init)
+
 let accountingNumber = OneOf {
-  Int.parser(isSigned: false)
+  digits
 
   Parse {
-    "("
-    Int.parser(isSigned: false)
-    ")"
+    "("; digits; ")"
   }
   .map { -$0 }
 }

--- a/Sources/Parsing/Documentation.docc/Articles/Design.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Design.md
@@ -79,7 +79,7 @@ to maximize readability of the parsers. For example, to parse accounting syntax 
 parenthesized numbers are negative, we can use the ``OneOf`` parser builder:
 
 ```swift
-let digits = Prefix { $0.isNumber }.compactMap(Int.init)
+let digits = Prefix { $0 >= "0" && $0 <= "9" }.compactMap(Int.init)
 
 let accountingNumber = OneOf {
   digits

--- a/Sources/Parsing/Documentation.docc/Articles/ErrorMessages.md
+++ b/Sources/Parsing/Documentation.docc/Articles/ErrorMessages.md
@@ -30,7 +30,7 @@ a parser that can parse accounting style of numbers, i.e. plain numbers are cons
 and numbers in parentheses are considered negative:
 
 ```swift
-let digits = Prefix { $0.isNumber }.compactMap(Int.init)
+let digits = Prefix { $0 >= "0" && $0 <= "9" }.compactMap(Int.init)
 
 let accountingNumber = OneOf {
   digits

--- a/Sources/Parsing/Documentation.docc/Articles/ErrorMessages.md
+++ b/Sources/Parsing/Documentation.docc/Articles/ErrorMessages.md
@@ -30,13 +30,13 @@ a parser that can parse accounting style of numbers, i.e. plain numbers are cons
 and numbers in parentheses are considered negative:
 
 ```swift
+let digits = Prefix { $0.isNumber }.compactMap(Int.init)
+
 let accountingNumber = OneOf {
-  Int.parser(isSigned: false)
+  digits
 
   Parse {
-    "("
-    Int.parser(isSigned: false)
-    ")"
+    "("; digits; ")"
   }
   .map { -$0 }
 }

--- a/Sources/Parsing/Documentation.docc/Articles/Parsers/Int.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Parsers/Int.md
@@ -60,7 +60,7 @@ then you will get an compiler error:
 
 ```swift
 let parser = Parse {
-  Int.parser() // 🛑 Ambiguous use of 'parser(of:isSigned:radix:)'
+  Int.parser() // 🛑 Ambiguous use of 'parser(of:radix:)'
   Bool.parser()
 }
 

--- a/Sources/Parsing/Parsers/Int.swift
+++ b/Sources/Parsing/Parsers/Int.swift
@@ -1,12 +1,11 @@
 extension FixedWidthInteger {
-  /// A parser that consumes an integer (with an optional leading `+` or `-` sign) from the
-  /// beginning of a collection of UTF-8 code units.
+  /// A parser that consumes an integer (with an optional leading `+` or `-` sign for signed integer
+  /// types) from the beginning of a collection of UTF-8 code units.
   ///
   /// See <doc:Int> for more information about this parser.
   ///
   /// - Parameters:
   ///   - inputType: The collection type of UTF-8 code units to parse.
-  ///   - isSigned: If the parser will attempt to parse a leading `+` or `-` sign.
   ///   - radix: The radix, or base, to use for converting text to an integer value. `radix` must be
   ///     in the range `2...36`.
   /// - Returns: A parser that consumes an integer from the beginning of a collection of UTF-8 code
@@ -14,14 +13,13 @@ extension FixedWidthInteger {
   @inlinable
   public static func parser<Input>(
     of inputType: Input.Type = Input.self,
-    isSigned: Bool = true,
     radix: Int = 10
   ) -> Parsers.IntParser<Input, Self> {
-    .init(isSigned: isSigned, radix: radix)
+    .init(radix: radix)
   }
 
-  /// A parser that consumes an integer (with an optional leading `+` or `-` sign) from the
-  /// beginning of a substring's UTF-8 view.
+  /// A parser that consumes an integer (with an optional leading `+` or `-` sign for signed integer
+  /// types) from the beginning of a collection of UTF-8 code units.
   ///
   /// This overload is provided to allow the `Input` generic to be inferred when it is
   /// `Substring.UTF8View`.
@@ -31,7 +29,6 @@ extension FixedWidthInteger {
   /// - Parameters:
   ///   - inputType: The `Substring.UTF8View` type. This parameter is included to mirror the
   ///     interface that parses any collection of UTF-8 code units.
-  ///   - isSigned: If the parser will attempt to parse a leading `+` or `-` sign.
   ///   - radix: The radix, or base, to use for converting text to an integer value. `radix` must be
   ///     in the range `2...36`.
   /// - Returns: A parser that consumes an integer from the beginning of a substring's UTF-8 view.
@@ -39,14 +36,13 @@ extension FixedWidthInteger {
   @inlinable
   public static func parser(
     of inputType: Substring.UTF8View.Type = Substring.UTF8View.self,
-    isSigned: Bool = true,
     radix: Int = 10
   ) -> Parsers.IntParser<Substring.UTF8View, Self> {
-    .init(isSigned: isSigned, radix: radix)
+    .init(radix: radix)
   }
 
-  /// A parser that consumes an integer (with an optional leading `+` or `-` sign) from the
-  /// beginning of a substring.
+  /// A parser that consumes an integer (with an optional leading `+` or `-` sign for signed integer
+  /// types) from the beginning of a collection of UTF-8 code units.
   ///
   /// This overload is provided to allow the `Input` generic to be inferred when it is `Substring`.
   ///
@@ -55,7 +51,6 @@ extension FixedWidthInteger {
   /// - Parameters:
   ///   - inputType: The `Substring` type. This parameter is included to mirror the interface that
   ///     parses any collection of UTF-8 code units.
-  ///   - isSigned: If the parser will attempt to parse a leading `+` or `-` sign.
   ///   - radix: The radix, or base, to use for converting text to an integer value. `radix` must be
   ///     in the range `2...36`.
   /// - Returns: A parser that consumes an integer from the beginning of a substring.
@@ -63,16 +58,15 @@ extension FixedWidthInteger {
   @inlinable
   public static func parser(
     of inputType: Substring.Type = Substring.self,
-    isSigned: Bool = true,
     radix: Int = 10
   ) -> FromUTF8View<Substring, Parsers.IntParser<Substring.UTF8View, Self>> {
-    .init { Parsers.IntParser<Substring.UTF8View, Self>(isSigned: isSigned, radix: radix) }
+    .init { Parsers.IntParser<Substring.UTF8View, Self>(radix: radix) }
   }
 }
 
 extension Parsers {
-  /// A parser that consumes an integer (with an optional leading `+` or `-` sign) from the
-  /// beginning of a collection of UTF8 code units.
+  /// A parser that consumes an integer (with an optional leading `+` or `-` sign for signed integer
+  /// types) from the beginning of a collection of UTF8 code units.
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the static `parser()` method on the `FixedWidthInteger` of your choice, e.g. `Int.parser()`,
@@ -84,16 +78,12 @@ extension Parsers {
     Input.SubSequence == Input,
     Input.Element == UTF8.CodeUnit
   {
-    /// If the parser will attempt to parse a leading `+` or `-` sign.
-    public let isSigned: Bool
-
     /// The radix, or base, to use for converting text to an integer value.
     public let radix: Int
 
     @inlinable
-    public init(isSigned: Bool = true, radix: Int = 10) {
+    public init(radix: Int = 10) {
       precondition((2...36).contains(radix), "Radix not in range 2...36")
-      self.isSigned = isSigned
       self.radix = radix
     }
 
@@ -123,7 +113,7 @@ extension Parsers {
       let parsedSign: Bool
       var overflow = false
       var output: Output
-      switch (self.isSigned, first) {
+      switch (Output.isSigned, first) {
       case (true, .init(ascii: "-")):
         parsedSign = true
         isPositive = false

--- a/Sources/swift-parsing-benchmark/Color.swift
+++ b/Sources/swift-parsing-benchmark/Color.swift
@@ -10,7 +10,7 @@ let colorSuite = BenchmarkSuite(name: "Color") { suite in
   }
 
   let hexPrimary = Prefix<Substring.UTF8View>(2).pipe {
-    UInt8.parser(isSigned: false, radix: 16)
+    UInt8.parser(radix: 16)
     End()
   }
 

--- a/Sources/swift-parsing-benchmark/Date.swift
+++ b/Sources/swift-parsing-benchmark/Date.swift
@@ -10,8 +10,11 @@ import Parsing
 /// while the formatters do not parse beyond the millisecond.
 let dateSuite = BenchmarkSuite(name: "Date") { suite in
   let digits = { (n: Int) in
-    Prefix<Substring.UTF8View>(n).pipe {
-      Int.parser(isSigned: false)
+    Prefix<Substring.UTF8View>(n) {
+      (.init(ascii: "0") ... .init(ascii: "9")).contains($0)
+    }
+    .pipe {
+      Int.parser()
       End()
     }
   }


### PR DESCRIPTION
We chatted about this awhile back and was fresh in mind after submitting #177.

I think it's probably a good default for this particular parser, especially since we can currently construct nonsensical parsers like `UInt.parser(isSigned: true)`.

If we need a simple numeric parser that doesn't consider the sign, maybe we should have a dedicated `Digits` parser?