### PR TITLE
Whitespace(.horizontal) and Whitespace(.vertical)

### DIFF
--- a/Sources/Parsing/Parser.swift
+++ b/Sources/Parsing/Parser.swift
@@ -117,7 +117,7 @@ extension Parser {
   /// >   Int.parser()
   /// >   ",".utf8
   /// >   Bool.parser()
-  /// >   Skip { Whitespace() }
+  /// >   Whitespace()
   /// > }
   /// > .parse("123,true    ") // (123, true)
   /// > ```
@@ -185,7 +185,7 @@ extension Parser {
   /// >  Int.parser()
   /// >  ",".utf8
   /// >  Bool.parser()
-  /// >  Skip { Whitespace() }
+  /// >  Whitespace()
   /// > }
   /// > .parse("123,true    ") // (123, true)
   /// > ```

--- a/Sources/Parsing/Parsers/Newline.swift
+++ b/Sources/Parsing/Parsers/Newline.swift
@@ -59,12 +59,6 @@ extension Newline where Input == Substring.UTF8View, Bytes == Input {
   public init() { self.init() }
 }
 
-extension Newline where Input == ArraySlice<UTF8.CodeUnit>, Bytes == Input {
-  @_disfavoredOverload
-  @inlinable
-  public init() { self.init() }
-}
-
 extension Parsers {
   public typealias Newline = Parsing.Newline  // NB: Convenience type alias for discovery
 }

--- a/Sources/swift-parsing-benchmark/JSON.swift
+++ b/Sources/swift-parsing-benchmark/JSON.swift
@@ -67,9 +67,9 @@ let jsonSuite = BenchmarkSuite(name: "JSON") { suite in
       let (name, value) = pair
       object[name] = value
     } element: {
-      Skip { Whitespace() }
+      Whitespace()
       string
-      Skip { Whitespace() }
+      Whitespace()
       ":".utf8
       Lazy { json! }
     } separator: {
@@ -91,7 +91,7 @@ let jsonSuite = BenchmarkSuite(name: "JSON") { suite in
   }
 
   json = Parse {
-    Skip { Whitespace() }
+    Whitespace()
     OneOf {
       object.map(JSONValue.object)
       array.map(JSONValue.array)
@@ -100,7 +100,7 @@ let jsonSuite = BenchmarkSuite(name: "JSON") { suite in
       Bool.parser().map(JSONValue.boolean)
       "null".utf8.map { JSONValue.null }
     }
-    Skip { Whitespace() }
+    Whitespace()
   }
   .eraseToAnyParser()
 

--- a/Tests/ParsingTests/OneOfTests.swift
+++ b/Tests/ParsingTests/OneOfTests.swift
@@ -250,9 +250,9 @@ final class OneOfTests: XCTestCase {
         let (name, value) = pair
         object[name] = value
       } element: {
-        Skip { Whitespace() }
+        Whitespace()
         string
-        Skip { Whitespace() }
+        Whitespace()
         ":".utf8
         Lazy { json! }
       } separator: {
@@ -274,7 +274,7 @@ final class OneOfTests: XCTestCase {
     }
 
     json = Parse {
-      Skip { Whitespace() }
+      Whitespace()
       OneOf {
         object.map(JSONValue.object)
         array.map(JSONValue.array)
@@ -283,7 +283,7 @@ final class OneOfTests: XCTestCase {
         Bool.parser().map(JSONValue.boolean)
         "null".utf8.map { JSONValue.null }
       }
-      Skip { Whitespace() }
+      Whitespace()
     }
     .eraseToAnyParser()
 

--- a/Tests/ParsingTests/WhitespaceTests.swift
+++ b/Tests/ParsingTests/WhitespaceTests.swift
@@ -2,7 +2,7 @@ import Parsing
 import XCTest
 
 final class WhitespaceTests: XCTestCase {
-  func testTrimsWhitespace() {
+  func testTrimsAllWhitespace() {
     var input = "    \r \t\t \r\n \n\r    Hello, world!"[...].utf8
     XCTAssertNotNil(Whitespace().parse(&input))
     XCTAssertEqual("Hello, world!", Substring(input))
@@ -12,5 +12,17 @@ final class WhitespaceTests: XCTestCase {
     var input = "Hello, world!"[...].utf8
     XCTAssertNotNil(Whitespace().parse(&input))
     XCTAssertEqual("Hello, world!", Substring(input))
+  }
+
+  func testTrimsHorizontalWhitespace() {
+    var input = "    \r \t\t \r\n \n\r    Hello, world!"[...].utf8
+    XCTAssertNotNil(Whitespace(.horizontal).parse(&input))
+    XCTAssertEqual("\r \t\t \r\n \n\r    Hello, world!", Substring(input))
+  }
+
+  func testTrimsVerticalWhitespace() {
+    var input = "\r\n\r\n \n\r    Hello, world!"[...].utf8
+    XCTAssertNotNil(Whitespace(.vertical).parse(&input))
+    XCTAssertEqual(" \n\r    Hello, world!", Substring(input))
   }
 }


### PR DESCRIPTION
This changes `Whitespace` to be a bit more reasonable to use:

- It can now be configured to consume only horizontal _or_ vertical whitespace.
- It is now Unicode friendly
- It is now `Void`-returning (trivia can be useful, but isn't a great default; we'll have a solution to this breaking change in a future PR)