### PR TITLE
Consumed parser

### DIFF
--- a/Sources/Parsing/Parsers/Consumed.swift
+++ b/Sources/Parsing/Parsers/Consumed.swift
@@ -1,0 +1,19 @@
+public struct Consumed<Upstream: Parser>: Parser
+where
+  Upstream.Input: Collection,
+  Upstream.Input.SubSequence == Upstream.Input
+{
+  public let upstream: Upstream
+
+  @inlinable
+  public init(@ParserBuilder _ build: () -> Upstream) {
+    self.upstream = build()
+  }
+
+  @inlinable
+  public func parse(_ input: inout Upstream.Input) rethrows -> Upstream.Input {
+    let original = input
+    _ = try self.upstream.parse(&input)
+    return original[..<input.startIndex]
+  }
+}

--- a/Tests/ParsingTests/ConsumedTests.swift
+++ b/Tests/ParsingTests/ConsumedTests.swift
@@ -1,0 +1,10 @@
+import Parsing
+import XCTest
+
+final class ConsumedTests: XCTestCase {
+  func testConsumed() throws {
+    var input = "    \r \t\t \r\n \n\r    Hello, world!"[...].utf8
+    XCTAssertEqual("    \r \t\t \r\n \n\r    ", Substring(Consumed { Whitespace() }.parse(&input)))
+    XCTAssertEqual("Hello, world!", Substring(input))
+  }
+}


### PR DESCRIPTION
A parser that returns the underlying sequence that was parsed, and a solution to a few problems:

  - The change in #185 that makes `Whitespace` a `Void` parser can be "undone" to explicitly return trivia by wrapping in `Consumed`:

    ```swift
    Consumed { Whitespace(.horizontal) }.parse("\t \t") // "\t \t"
    ```

  - A complex parser built from many parts that only cares about the consumed sequence:

    ```swift
    Consumed {
      Many {
        Prefix { $0.isLetter }
        " "
      }
      Prefix { $0.isLetter }
    }
    ```