### PR TITLE
Complete Whitespace cases

### DIFF
--- a/Sources/Parsing/Parsers/Whitespace.swift
+++ b/Sources/Parsing/Parsers/Whitespace.swift
@@ -26,19 +26,30 @@ where
 
     @inline(__always)
     func consumeHorizontal() -> Bool {
+      // Unicode chars from `CharacterSet.whitespaces`
+      // General category Zs + \t
       switch bytes.first {
-      case .init(ascii: " "), .init(ascii: "\t"):
+      case 0x20, 0x9: // U+0020, \t (U+0009)
         bytes.removeFirst()
         return true
 
-      case 194:
-        if bytes.dropFirst().first == 160 {
+      case 194: // U+00A0
+        if bytes.dropFirst().first == 0xA0 {
           bytes.removeFirst(2)
           return true
         }
         return false
+        
+      case 225: // U+1680
+        if bytes.dropFirst().first == 154,
+          bytes.dropFirst(2).first == 128
+        {
+          bytes.removeFirst(3)
+          return true
+        }
+        return false
 
-      case 226:
+      case 226: // U+2000 ~ U+200A, U+202F
         switch bytes.dropFirst().first {
         case 128:
           if let byte = bytes.dropFirst(2).first,
@@ -49,7 +60,7 @@ where
           }
           return false
 
-        case 129:
+        case 129: // U+205F
           if bytes.dropFirst(2).first == 159 {
             bytes.removeFirst(3)
             return true
@@ -60,7 +71,7 @@ where
           return false
         }
 
-      case 227:
+      case 227: // U+3000
         if bytes.dropFirst().starts(with: [128, 128]) {
           bytes.removeFirst(3)
           return true
@@ -74,12 +85,20 @@ where
 
     @inline(__always)
     func consumeVertical() -> Bool {
+      // Unicode chars from `CharacterSet.newlines`
       switch bytes.first {
-      case .init(ascii: "\n"), .init(ascii: "\r"):
+      case 0xA, 0xB, 0xC, 0xD: // U+000A ~ U+000D
         bytes.removeFirst()
         return true
-
-      case 226:
+        
+      case 194: // U+0085
+        if bytes.dropFirst().first == 0x85 {
+          bytes.removeFirst(2)
+          return true
+        }
+        return false
+        
+      case 226: // U+2028, U+2029
         if bytes.dropFirst().first == 128,
           let byte = bytes.dropFirst(2).first,
           byte == 168 || byte == 169

--- a/Sources/Parsing/Parsers/Whitespace.swift
+++ b/Sources/Parsing/Parsers/Whitespace.swift
@@ -87,7 +87,7 @@ where
     func consumeVertical() -> Bool {
       // Unicode chars from `CharacterSet.newlines`
       switch bytes.first {
-      case 0xA, 0xB, 0xC, 0xD: // U+000A ~ U+000D
+      case 0xA ... 0xD: // U+000A ~ U+000D
         bytes.removeFirst()
         return true
         

--- a/Sources/Parsing/Parsers/Whitespace.swift
+++ b/Sources/Parsing/Parsers/Whitespace.swift
@@ -87,7 +87,7 @@ where
     func consumeVertical() -> Bool {
       // Unicode chars from `CharacterSet.newlines`
       switch bytes.first {
-      case 0xA ... 0xD: // U+000A ~ U+000D
+      case 0xA, 0xB, 0xC, 0xD: // U+000A ~ U+000D
         bytes.removeFirst()
         return true
         


### PR DESCRIPTION
Following #185, I've completed the list of cases to match `CharacterSet.whitespace` and `CharacterSet.newlines`.
I've added 1 horizontal case (`U+1680`).
I've added 3 vertical cases (`U+000B`, `U+000C`, and `U+0085`).
For consistency, I've replaced `.init(ascii:)` occurrences with their corresponding hexadecimal literal value. I've also used hexadecimal literals instead of decimal when they match UTF-8 codepoints. I can switch to all decimal/hexadecimal if preferable.
I've also added a few comments to improve readability. 
I can reverse these last changes if needed.
I didn't add new tests as the current implementation isn't exhaustive either. I can add a few ones if needed.