### PR TITLE
Require pipes over collections of input to fully consume input

### DIFF
--- a/Sources/Parsing/Parsers/Pipe.swift
+++ b/Sources/Parsing/Parsers/Pipe.swift
@@ -69,8 +69,8 @@ extension Parsers {
   }
 
   public struct PipeEnd<Input: Collection>: Parser {
-    @inlinable
-    public init() {}
+    @usableFromInline
+    init() {}
 
     @inlinable
     public func parse(_ input: inout Input) throws {

--- a/Sources/Parsing/Parsers/Pipe.swift
+++ b/Sources/Parsing/Parsers/Pipe.swift
@@ -37,6 +37,14 @@ extension Parser {
   }
 }
 
+extension Parser where Input: Collection {
+  public func pipe<Downstream>(
+    @ParserBuilder _ build: () -> Downstream
+  ) -> Parsers.Pipe<Self, Parse<ParserBuilder.ZipOV<Downstream, Parsers.PipeEnd<Self.Input>>>> {
+    .init(upstream: self, downstream: Parse { build(); Parsers.PipeEnd<Input>() })
+  }
+}
+
 extension Parsers {
   /// A parser that runs this parser, pipes its output into the given parser, and returns the output
   /// of the given parser.
@@ -56,20 +64,18 @@ extension Parsers {
 
     @inlinable
     public func parse(_ input: inout Upstream.Input) rethrows -> Downstream.Output {
-      let original = input
-      var downstreamInput = try self.upstream.parse(&input)
-      do {
-        return try self.downstream.parse(&downstreamInput)
-      } catch let ParsingError.failed(reason, context) {
-        throw ParsingError.failed(
-          "pipe: \(reason)",
-          .init(
-            originalInput: original,
-            remainingInput: input,
-            debugDescription: context.debugDescription,
-            underlyingError: ParsingError.failed(reason, context)
-          )
-        )
+      try self.downstream.parse(self.upstream.parse(&input))
+    }
+  }
+
+  public struct PipeEnd<Input: Collection>: Parser {
+    @inlinable
+    public init() {}
+
+    @inlinable
+    public func parse(_ input: inout Input) throws {
+      guard input.isEmpty else {
+        throw ParsingError.expectedInput("end of pipe", from: input, to: input[input.endIndex...])
       }
     }
   }

--- a/Tests/ParsingTests/PipeTests.swift
+++ b/Tests/ParsingTests/PipeTests.swift
@@ -49,19 +49,4 @@ final class PipeTests: XCTestCase {
     }
     XCTAssertEqual("true", Substring(input))
   }
-
-  func testPipeEnd() {
-    var input = "DH0000"[...]
-    XCTAssertThrowsError(try Prefix(2).pipe { UInt8.parser(radix: 16) }.parse(&input)) { error in
-      XCTAssertEqual(
-        """
-        error: unexpected input
-         --> input:1:2
-        1 | DH0000
-          |  ^ expected end of pipe
-        """,
-        "\(error)"
-      )
-    }
-  }
 }

--- a/Tests/ParsingTests/PipeTests.swift
+++ b/Tests/ParsingTests/PipeTests.swift
@@ -4,30 +4,29 @@ import XCTest
 final class PipeTests: XCTestCase {
   func testSuccess() {
     var input = "true Hello, world!"[...].utf8
-    XCTAssertEqual(true, try Prefix(5).pipe { Bool.parser() }.parse(&input))
-    XCTAssertEqual("Hello, world!", Substring(input))
+    XCTAssertEqual(true, try Prefix(4).pipe { Bool.parser() }.parse(&input))
+    XCTAssertEqual(" Hello, world!", Substring(input))
   }
 
   func testFailureOutput() {
     var input = "true Hello, world!"[...].utf8
     XCTAssertThrowsError(
-      try Prefix(5).pipe {
+      try Prefix(10).pipe {
         Bool.parser()
-        End()
       }
       .parse(&input)
     ) { error in
       XCTAssertEqual(
         """
         error: unexpected input
-         --> input:1:1-5
+         --> input:1:5-10
         1 | true Hello, world!
-          | ^^^^^ pipe: expected end of input
+          |     ^^^^^^ expected end of pipe
         """,
         "\(error)"
       )
     }
-    XCTAssertEqual("Hello, world!", Substring(input))
+    XCTAssertEqual(", world!", Substring(input))
   }
 
   func testFailureInput() {
@@ -49,5 +48,20 @@ final class PipeTests: XCTestCase {
       )
     }
     XCTAssertEqual("true", Substring(input))
+  }
+
+  func testPipeEnd() {
+    var input = "DH0000"[...]
+    XCTAssertThrowsError(try Prefix(2).pipe { UInt8.parser(radix: 16) }.parse(&input)) { error in
+      XCTAssertEqual(
+        """
+        error: unexpected input
+         --> input:1:2
+        1 | DH0000
+          |  ^ expected end of pipe
+        """,
+        "\(error)"
+      )
+    }
   }
 }


### PR DESCRIPTION
I was surprised to find a parser was succeeding because a parser pipe was happily discarding trailing input.

Calling the non-inout version of `.parse(string)` inserts an `End` parser automatically, and I think we should have similar behavior here. So this PR appends a `PipeEnd` parser to the end of a parser pipe when the input is a collection. `PipeEnd` is basically an `End` parser with custom error behavior.