### PR TITLE
RFC: Use `buildExpression` to promote substring parsers to UTF-8

### DIFF
--- a/Sources/Parsing/Builders/OneOfBuilder.swift
+++ b/Sources/Parsing/Builders/OneOfBuilder.swift
@@ -18,6 +18,20 @@
 /// ```
 @resultBuilder
 public enum OneOfBuilder {
+  /// Provides support for specifying a parser in ``OneOfBuilder`` blocks.
+  @inlinable
+  public static func buildExpression<P: Parser>(_ parser: P) -> P {
+    parser
+  }
+
+  /// Provides support for specifying a substring parser in a UTF-8 ``OneOfBuilder`` block.
+  @inlinable
+  public static func buildExpression<P>(
+    _ parser: P
+  ) -> FromSubstring<Substring.UTF8View, P> {
+    FromSubstring(substringParser: parser, toSubstring: Substring.init, fromSubstring: { $0.utf8 })
+  }
+
   /// Provides support for `for`-`in` loops in ``OneOfBuilder`` blocks.
   ///
   /// Useful for building up a parser from a dynamic source, like for a case-iterable enum:

--- a/Sources/Parsing/Builders/ParserBuilder.swift
+++ b/Sources/Parsing/Builders/ParserBuilder.swift
@@ -14,6 +14,26 @@
 /// ```
 @resultBuilder
 public enum ParserBuilder {
+  /// Provides support for specifying an "empty" parser in ``ParserBuilder`` blocks.
+  @inlinable
+  public static func buildBlock() -> Always<Substring.UTF8View, Void> {
+    .init(())
+  }
+
+  /// Provides support for specifying a parser in ``ParserBuilder`` blocks.
+  @inlinable
+  public static func buildExpression<P: Parser>(_ parser: P) -> P {
+    parser
+  }
+
+  /// Provides support for specifying a substring parser in a UTF-8 ``ParserBuilder`` block.
+  @inlinable
+  public static func buildExpression<P>(
+    _ parser: P
+  ) -> FromSubstring<Substring.UTF8View, P> {
+    FromSubstring(substringParser: parser, toSubstring: Substring.init, fromSubstring: { $0.utf8 })
+  }
+
   /// Provides support for specifying a parser in ``ParserBuilder`` blocks.
   @inlinable
   public static func buildBlock<P: Parser>(_ parser: P) -> P {

--- a/Sources/Parsing/Parsers/Bool.swift
+++ b/Sources/Parsing/Parsers/Bool.swift
@@ -30,22 +30,6 @@ extension Bool {
   ) -> Parsers.BoolParser<Substring.UTF8View> {
     .init()
   }
-
-  /// A parser that consumes a Boolean value from the beginning of a substring.
-  ///
-  /// This overload is provided to allow the `Input` generic to be inferred when it is `Substring`.
-  ///
-  /// See <doc:Bool> for more information about this parser.
-  ///
-  /// - Parameter inputType: The `Substring` type. This parameter is included to mirror the
-  ///   interface that parses any collection of UTF-8 code units.
-  /// - Returns: A parser that consumes a Boolean value from the beginning of a substring.
-  @inlinable
-  public static func parser(
-    of inputType: Substring.Type = Substring.self
-  ) -> FromUTF8View<Substring, Parsers.BoolParser<Substring.UTF8View>> {
-    .init { Parsers.BoolParser<Substring.UTF8View>() }
-  }
 }
 
 extension Parsers {

--- a/Sources/Parsing/Parsers/Float.swift
+++ b/Sources/Parsing/Parsers/Float.swift
@@ -32,23 +32,6 @@ extension BinaryFloatingPoint where Self: LosslessStringConvertible {
   ) -> Parsers.FloatParser<Substring.UTF8View, Self> {
     .init()
   }
-
-  /// A parser that consumes a floating-point number from the beginning of a substring.
-  ///
-  /// This overload is provided to allow the `Input` generic to be inferred when it is `Substring`.
-  ///
-  /// See <doc:Float> for more information about this parser.
-  ///
-  /// - Parameter inputType: The `Substring` type. This parameter is included to mirror the
-  ///   interface that parses any collection of UTF-8 code units.
-  /// - Returns: A parser that consumes a floating-point number from the beginning of a substring.
-  @_disfavoredOverload
-  @inlinable
-  public static func parser(
-    of inputType: Substring.Type = Substring.self
-  ) -> FromUTF8View<Substring, Parsers.FloatParser<Substring.UTF8View, Self>> {
-    .init { Parsers.FloatParser<Substring.UTF8View, Self>() }
-  }
 }
 
 extension Parsers {

--- a/Sources/Parsing/Parsers/FromSubstring.swift
+++ b/Sources/Parsing/Parsers/FromSubstring.swift
@@ -35,6 +35,17 @@ where SubstringParser.Input == Substring {
   public let toSubstring: (Input) -> Substring
   public let fromSubstring: (Substring) -> Input
 
+  @usableFromInline
+  init(
+    substringParser: SubstringParser,
+    toSubstring: @escaping (Input) -> Substring,
+    fromSubstring: @escaping (Substring) -> Input
+  ) {
+    self.substringParser = substringParser
+    self.toSubstring = toSubstring
+    self.fromSubstring = fromSubstring
+  }
+
   @inlinable
   public func parse(_ input: inout Input) rethrows -> SubstringParser.Output {
     var substring = self.toSubstring(input)

--- a/Sources/Parsing/Parsers/Int.swift
+++ b/Sources/Parsing/Parsers/Int.swift
@@ -40,28 +40,6 @@ extension FixedWidthInteger {
   ) -> Parsers.IntParser<Substring.UTF8View, Self> {
     .init(radix: radix)
   }
-
-  /// A parser that consumes an integer (with an optional leading `+` or `-` sign for signed integer
-  /// types) from the beginning of a collection of UTF-8 code units.
-  ///
-  /// This overload is provided to allow the `Input` generic to be inferred when it is `Substring`.
-  ///
-  /// See <doc:Int> for more information about this parser.
-  ///
-  /// - Parameters:
-  ///   - inputType: The `Substring` type. This parameter is included to mirror the interface that
-  ///     parses any collection of UTF-8 code units.
-  ///   - radix: The radix, or base, to use for converting text to an integer value. `radix` must be
-  ///     in the range `2...36`.
-  /// - Returns: A parser that consumes an integer from the beginning of a substring.
-  @_disfavoredOverload
-  @inlinable
-  public static func parser(
-    of inputType: Substring.Type = Substring.self,
-    radix: Int = 10
-  ) -> FromUTF8View<Substring, Parsers.IntParser<Substring.UTF8View, Self>> {
-    .init { Parsers.IntParser<Substring.UTF8View, Self>(radix: radix) }
-  }
 }
 
 extension Parsers {

--- a/Sources/Parsing/Parsers/Newline.swift
+++ b/Sources/Parsing/Parsers/Newline.swift
@@ -9,51 +9,27 @@
 ///   Prefix(1) { $0.isNewline }
 ///   ```
 /// It will consume both line feeds (`"\n"`) and carriage returns with line feeds (`"\r\n"`).
-public struct Newline<Input: Collection, Bytes: Collection>: Parser
+public struct Newline<Input: Collection>: Parser
 where
   Input.SubSequence == Input,
-  Bytes.SubSequence == Bytes,
-  Bytes.Element == UTF8.CodeUnit
+  Input.Element == UTF8.CodeUnit
 {
-  @usableFromInline
-  let toBytes: (Input) -> Bytes
-
-  @usableFromInline
-  let fromBytes: (Bytes) -> Input
+  @inlinable
+  public init() {}
 
   @inlinable
   public func parse(_ input: inout Input) throws {
-    var bytes = self.toBytes(input)
-    if bytes.first == .init(ascii: "\n") {
-      bytes.removeFirst()
-    } else if bytes.first == .init(ascii: "\r"), bytes.dropFirst().first == .init(ascii: "\n") {
-      bytes.removeFirst(2)
+    if input.first == .init(ascii: "\n") {
+      input.removeFirst()
+    } else if input.first == .init(ascii: "\r"), input.dropFirst().first == .init(ascii: "\n") {
+      input.removeFirst(2)
     } else {
       throw ParsingError.expectedInput(#""\n" or "\r\n""#, at: input)
     }
-    input = self.fromBytes(bytes)
   }
 }
 
-// NB: Swift 5.5.2 on Linux and Windows fails to build with a simpler `Bytes == Input` constraint
-extension Newline where Bytes == Input.SubSequence, Bytes.SubSequence == Input {
-  @inlinable
-  public init() {
-    self.toBytes = { $0 }
-    self.fromBytes = { $0 }
-  }
-}
-
-extension Newline where Input == Substring, Bytes == Substring.UTF8View {
-  @_disfavoredOverload
-  @inlinable
-  public init() {
-    self.toBytes = { $0.utf8 }
-    self.fromBytes = Substring.init
-  }
-}
-
-extension Newline where Input == Substring.UTF8View, Bytes == Input {
+extension Newline where Input == Substring.UTF8View {
   @_disfavoredOverload
   @inlinable
   public init() { self.init() }

--- a/Sources/Parsing/Parsers/Rest.swift
+++ b/Sources/Parsing/Parsers/Rest.swift
@@ -23,7 +23,7 @@
 /// to coalesce the error into a default output value.
 public struct Rest<Input: Collection>: Parser where Input.SubSequence == Input {
   @inlinable
-  public init() {}
+  public init(of inputType: Input.Type = Input.self) {}
 
   @inlinable
   public func parse(_ input: inout Input) throws -> Input {

--- a/Sources/Parsing/Parsers/UUID.swift
+++ b/Sources/Parsing/Parsers/UUID.swift
@@ -36,21 +36,6 @@ extension UUID {
   ) -> Parsers.UUIDParser<Substring.UTF8View> {
     .init()
   }
-
-  /// A parser that consumes a hexadecimal UUID from the beginning of a substring.
-  ///
-  /// This overload is provided to allow the `Input` generic to be inferred when it is `Substring`.
-  ///
-  /// - Parameter inputType: The `Substring` type. This parameter is included to mirror the
-  ///   interface that parses any collection of UTF-8 code units.
-  /// - Returns: A parser that consumes a hexadecimal UUID from the beginning of a substring.
-  @_disfavoredOverload
-  @inlinable
-  public static func parser(
-    of inputType: Substring.Type = Substring.self
-  ) -> FromUTF8View<Substring, Parsers.UUIDParser<Substring.UTF8View>> {
-    .init { Parsers.UUIDParser<Substring.UTF8View>() }
-  }
 }
 
 extension Parsers {

--- a/Sources/swift-parsing-benchmark/ReadmeExample.swift
+++ b/Sources/swift-parsing-benchmark/ReadmeExample.swift
@@ -39,8 +39,7 @@ let readmeExampleSuite = BenchmarkSuite(name: "README Example") { suite in
     }
 
     suite.benchmark("Parser: Substring") {
-      var input = input[...]
-      output = try users.parse(&input)
+      output = try users.parse(input)
     } tearDown: {
       precondition(output == expectedOutput)
     }
@@ -63,8 +62,7 @@ let readmeExampleSuite = BenchmarkSuite(name: "README Example") { suite in
     }
 
     suite.benchmark("Parser: UTF8") {
-      var input = input[...].utf8
-      output = try users.parse(&input)
+      output = try users.parse(input)
     } tearDown: {
       precondition(output == expectedOutput)
     }

--- a/Sources/swift-parsing-benchmark/Routing.swift
+++ b/Sources/swift-parsing-benchmark/Routing.swift
@@ -37,11 +37,11 @@ let routingSuite = BenchmarkSuite(name: "Routing") { suite in
       Route(AppRoute.home)
 
       Route(AppRoute.contactUs) {
-        Path(FromUTF8View { "contact-us".utf8 })
+        Path("contact-us".utf8)
       }
 
       Route(AppRoute.episodes) {
-        Path(FromUTF8View { "episodes".utf8 })
+        Path("episodes".utf8)
 
         OneOf {
           Route(Episodes.index)
@@ -53,7 +53,7 @@ let routingSuite = BenchmarkSuite(name: "Routing") { suite in
               Route(Episode.show)
 
               Route(Episode.comments) {
-                Path(FromUTF8View { "comments".utf8 })
+                Path("comments".utf8)
 
                 OneOf {
                   Route(Comments.post) {

--- a/Sources/swift-parsing-benchmark/StringAbstractions.swift
+++ b/Sources/swift-parsing-benchmark/StringAbstractions.swift
@@ -27,7 +27,7 @@ let stringAbstractionsSuite = BenchmarkSuite(name: "String Abstractions") { suit
       // NB: omitting `of: Substring.UTF8View.self` causes a segfault in Xcode 12.5.1 (Swift 5.4.1)
       Int.parser(of: Substring.UTF8View.self)
     } separator: {
-      FromSubstring { "\u{00E9}" }
+      "\u{00E9}"
     }
     .parse(&input)
   } tearDown: {

--- a/Sources/swift-parsing-benchmark/URLRequestRouter/URLRequestRouter.swift
+++ b/Sources/swift-parsing-benchmark/URLRequestRouter/URLRequestRouter.swift
@@ -103,7 +103,7 @@
   struct Path<Component>: Parser
   where
     Component: Parser,
-    Component.Input == Substring
+    Component.Input == Substring.UTF8View
   {
     let componentParser: Component
 
@@ -119,7 +119,7 @@
         throw ParsingError()
       }
 
-      let output = try self.componentParser.parse(&component)
+      let output = try self.componentParser.parse(&component.utf8)
 
       guard component.isEmpty
       else {
@@ -145,7 +145,7 @@
   struct Query<Value>: Parser
   where
     Value: Parser,
-    Value.Input == Substring
+    Value.Input == Substring.UTF8View
   {
     let defaultValue: Value.Output?
     let name: String
@@ -166,7 +166,7 @@
     init(
       _ name: String,
       default defaultValue: Value.Output? = nil
-    ) where Value == Rest<Substring> {
+    ) where Value == Rest<Substring.UTF8View> {
       self.init(
         name,
         Rest(),
@@ -193,7 +193,7 @@
 
       let output: Value.Output
       do {
-        output = try self.valueParser.parse(&value)
+        output = try self.valueParser.parse(&value.utf8)
       } catch {
         return try defaultOrError(error)
       }

--- a/Sources/swift-parsing-benchmark/XCTestLogs.swift
+++ b/Sources/swift-parsing-benchmark/XCTestLogs.swift
@@ -50,7 +50,7 @@ private let testCaseBody = Parse {
 struct TestCaseBody: Parser {
   func parse(
     _ input: inout Substring.UTF8View
-  ) throws -> (file: Substring.UTF8View, line: Int, message: Substring.UTF8View) {
+  ) throws -> (file: Substring.UTF8View, line: Int, message: Substring) {
     guard input.first == .init(ascii: "/")
     else { throw ParsingError() }
 
@@ -98,7 +98,7 @@ private let testFailed = Parse {
 .map { testName, bodyData, time in
   bodyData.map { body in
     TestResult.failed(
-      failureMessage: Substring(body.2),
+      failureMessage: body.2,
       file: Substring(body.0),
       line: body.1,
       testName: Substring(testName),

--- a/Tests/ParsingTests/ConditionalTests.swift
+++ b/Tests/ParsingTests/ConditionalTests.swift
@@ -13,13 +13,13 @@ final class ConditionalTests: XCTestCase {
 
   func testFirst() {
     var input = "42 Hello, world!"[...]
-    XCTAssertEqual(true, try parser.parse(&input))
+    XCTAssertEqual(true, try parser.parse(&input.utf8))
     XCTAssertEqual(" Hello, world!", input)
   }
 
   func testSecond() {
     var input = "43 Hello, world!"[...]
-    XCTAssertThrowsError(try parser.parse(&input)) { error in
+    XCTAssertThrowsError(try parser.parse(&input.utf8)) { error in
       XCTAssertEqual(
         """
         error: OddNumberError()

--- a/Tests/ParsingTests/FromSubstringTests.swift
+++ b/Tests/ParsingTests/FromSubstringTests.swift
@@ -5,7 +5,7 @@ final class FromSubstringTests: XCTestCase {
   func testUTF8View() {
     let p = Parse {
       "caf".utf8
-      FromSubstring { "é" }
+      "é"
     }
 
     var input = "caf\u{00E9}"[...].utf8

--- a/Tests/ParsingTests/ManyTests.swift
+++ b/Tests/ParsingTests/ManyTests.swift
@@ -117,7 +117,7 @@ class ManyTests: XCTestCase {
       } separator: {
         ":"
       }
-      .parse(&input),
+      .parse(&input.utf8),
       ["2001", "db8", "", "2", "1"]
     )
   }
@@ -156,7 +156,7 @@ class ManyTests: XCTestCase {
         User(id: 2, name: "Blob Sr", isAdmin: false),
         User(id: 3, name: "Blob Jr", isAdmin: true),
       ],
-      try users.parse(&input)
+      try users.parse(&input.utf8)
     )
 
     input = """
@@ -164,7 +164,7 @@ class ManyTests: XCTestCase {
       2,Blob Sr,false
       3,Blob Jr,tru
       """
-    XCTAssertThrowsError(try users.parse(&input)) { error in
+    XCTAssertThrowsError(try users.parse(&input.utf8)) { error in
       XCTAssertEqual(
         """
         error: multiple failures occurred
@@ -194,7 +194,7 @@ class ManyTests: XCTestCase {
     }
 
     var input = "1,2,3-"[...]
-    XCTAssertThrowsError(try intsParser.parse(&input)) { error in
+    XCTAssertThrowsError(try intsParser.parse(&input.utf8)) { error in
       XCTAssertEqual(
         """
         error: unexpected input

--- a/Tests/ParsingTests/NotTests.swift
+++ b/Tests/ParsingTests/NotTests.swift
@@ -17,7 +17,7 @@ class NotTests: XCTestCase {
       }
     }
 
-    XCTAssertEqual(try uncommentedLine.parse(&input), "let foo = true")
+    XCTAssertEqual(try uncommentedLine.parse(&input.utf8), "let foo = true")
     XCTAssertEqual(input, "let bar = false")
   }
 
@@ -32,7 +32,7 @@ class NotTests: XCTestCase {
       Prefix { $0 != "\n" }
     }
 
-    XCTAssertThrowsError(try uncommentedLine.parse(&input))
+    XCTAssertThrowsError(try uncommentedLine.parse(&input.utf8))
     XCTAssertEqual(
       input,
       """

--- a/Tests/ParsingTests/OneOfTests.swift
+++ b/Tests/ParsingTests/OneOfTests.swift
@@ -9,7 +9,7 @@ final class OneOfTests: XCTestCase {
         "New York"
         "Berlin"
       }
-      .parse(&input)
+      .parse(&input.utf8)
     )
     XCTAssertEqual(", Hello!", Substring(input))
   }
@@ -21,7 +21,7 @@ final class OneOfTests: XCTestCase {
         "New York"
         "Berlin"
       }
-      .parse(&input)
+      .parse(&input.utf8)
     )
     XCTAssertEqual(", Hello!", Substring(input))
   }
@@ -33,7 +33,7 @@ final class OneOfTests: XCTestCase {
         "New York"
         "Berlin"
       }
-      .parse(&input)
+      .parse(&input.utf8)
     ) { error in
       XCTAssertEqual(
         """
@@ -57,7 +57,7 @@ final class OneOfTests: XCTestCase {
           city
         }
       }
-      .parse(&input)
+      .parse(&input.utf8)
     )
     XCTAssertEqual(", Hello!", Substring(input))
   }
@@ -70,7 +70,7 @@ final class OneOfTests: XCTestCase {
           city
         }
       }
-      .parse(&input)
+      .parse(&input.utf8)
     )
     XCTAssertEqual(", Hello!", Substring(input))
   }
@@ -92,7 +92,7 @@ final class OneOfTests: XCTestCase {
           parser
         }
       }
-      .parse(&input)
+      .parse(&input.utf8)
     ) { error in
       XCTAssertEqual(
         """
@@ -121,7 +121,7 @@ final class OneOfTests: XCTestCase {
         "New York"
         "Berlin"
       }
-      .parse(&input)
+      .parse(&input.utf8)
     ) { error in
       XCTAssertEqual(
         """

--- a/Tests/ParsingTests/ParserBuilderTests.swift
+++ b/Tests/ParsingTests/ParserBuilderTests.swift
@@ -14,11 +14,11 @@ final class ParserBuilderTests: XCTestCase {
       "!"
     }
     var input = "Hello, world!"[...]
-    XCTAssertEqual("world", try parser.parse(&input))
+    XCTAssertEqual("world", try parser.parse(&input.utf8))
     XCTAssertEqual(input, ""[...])
 
     input = "Hello world!"[...]
-    XCTAssertThrowsError(try parser.parse(&input)) { error in
+    XCTAssertThrowsError(try parser.parse(&input.utf8)) { error in
       XCTAssertEqual(
         """
         error: unexpected input
@@ -42,11 +42,11 @@ final class ParserBuilderTests: XCTestCase {
       "!"
     }
     input = "Hello world!"
-    XCTAssertEqual("world", try parser.parse(&input))
+    XCTAssertEqual("world", try parser.parse(&input.utf8))
     XCTAssertEqual(input, ""[...])
 
     input = "Hello, world!"
-    XCTAssertThrowsError(try parser.parse(&input)) { error in
+    XCTAssertThrowsError(try parser.parse(&input.utf8)) { error in
       XCTAssertEqual(
         """
         error: unexpected input
@@ -70,13 +70,13 @@ final class ParserBuilderTests: XCTestCase {
       Rest()
     }
     var input = "42 Blob"[...]
-    var (int, string) = try XCTUnwrap(parser.parse(&input))
+    var (int, string) = try XCTUnwrap(parser.parse(&input.utf8))
     XCTAssertEqual(42, int)
     XCTAssertEqual("Blob", string)
     XCTAssertEqual(input, ""[...])
 
     input = "Blob"
-    XCTAssertThrowsError(try parser.parse(&input)) { error in
+    XCTAssertThrowsError(try parser.parse(&input.utf8)) { error in
       XCTAssertEqual(
         """
         error: unexpected input
@@ -98,7 +98,7 @@ final class ParserBuilderTests: XCTestCase {
       Rest()
     }
     input = "Blob"
-    (int, string) = try XCTUnwrap(parser.parse(&input))
+    (int, string) = try XCTUnwrap(parser.parse(&input.utf8))
     XCTAssertEqual(nil, int)
     XCTAssertEqual("Blob", string)
     XCTAssertEqual(input, ""[...])
@@ -122,7 +122,7 @@ final class ParserBuilderTests: XCTestCase {
         Int.parser()
         MyParser()
       }
-      .parse(&input)
+      .parse(&input.utf8)
     ) { error in
       XCTAssertEqual(
         """
@@ -145,7 +145,7 @@ final class ParserBuilderTests: XCTestCase {
         Int.parser()
         MyParser()
       }
-      .parse(&input)
+      .parse(&input.utf8)
     ) { error in
       XCTAssertEqual(
         """

--- a/Tests/ParsingTests/PeekTests.swift
+++ b/Tests/ParsingTests/PeekTests.swift
@@ -10,7 +10,7 @@ class PeekTests: XCTestCase {
       Prefix { $0.isNumber || $0.isLetter || $0 == "_" }
     }
 
-    XCTAssertEqual("_foo1"[...], try identifier.parse(&input))
+    XCTAssertEqual("_foo1"[...], try identifier.parse(&input.utf8))
     XCTAssertEqual(" = nil", input)
   }
 
@@ -26,7 +26,7 @@ class PeekTests: XCTestCase {
       Prefix { $0.isNumber || $0.isLetter || $0 == "_" }
     }
 
-    XCTAssertThrowsError(try identifier.parse(&input))
+    XCTAssertThrowsError(try identifier.parse(&input.utf8))
     XCTAssertEqual("1foo = nil", input)
   }
 
@@ -38,7 +38,7 @@ class PeekTests: XCTestCase {
       "bar"
     }
 
-    XCTAssertThrowsError(try parser.parse(&input))
+    XCTAssertThrowsError(try parser.parse(&input.utf8))
     XCTAssertEqual("blah"[...], input)
   }
 }

--- a/Tests/ParsingTests/ReplaceErrorTests.swift
+++ b/Tests/ParsingTests/ReplaceErrorTests.swift
@@ -9,7 +9,7 @@ final class ReplaceErrorTests: XCTestCase {
       Parse {
         Int.parser()
         "!"
-      }.replaceError(with: 0).parse(&input))
+      }.replaceError(with: 0).parse(&input.utf8))
     XCTAssertEqual("123", input)
   }
 }

--- a/Tests/ParsingTests/UTF8Tests.swift
+++ b/Tests/ParsingTests/UTF8Tests.swift
@@ -3,14 +3,14 @@ import XCTest
 
 final class UTF8Tests: XCTestCase {
   func testSubstringNormalization() {
-    var input = "\u{00E9}e\u{0301}e\u{0341} Hello, world"[...].utf8
-    let parser = FromSubstring<Substring.UTF8View, String> { "é" }
+    var input = "\u{00E9}e\u{0301}e\u{0341} Hello, world"[...]
+    let parser = "é"
     XCTAssertNoThrow(try parser.parse(&input))
-    XCTAssertEqual("e\u{0301}e\u{0341} Hello, world", Substring(input))
+    XCTAssertEqual("e\u{0301}e\u{0341} Hello, world", input)
     XCTAssertNoThrow(try parser.parse(&input))
-    XCTAssertEqual("e\u{0341} Hello, world", Substring(input))
+    XCTAssertEqual("e\u{0341} Hello, world", input)
     XCTAssertNoThrow(try parser.parse(&input))
-    XCTAssertEqual(" Hello, world", Substring(input))
+    XCTAssertEqual(" Hello, world", input)
     XCTAssertThrowsError(try parser.parse(&input)) { error in
       XCTAssertEqual(
         """
@@ -22,7 +22,7 @@ final class UTF8Tests: XCTestCase {
         "\(error)"
       )
     }
-    XCTAssertEqual(" Hello, world", Substring(input))
+    XCTAssertEqual(" Hello, world", input)
   }
 
   func testUnicodeScalars() {


### PR DESCRIPTION
This PR introduces substantial changes to parser builder block behavior, which may not be quite right yet, but we think it's a _step_ in the right direction to make the library much more approachable.

First, it adds an empty `ParserBuilder.buildBlock()`, so that this is now valid:

```swift
let parser = Parse {}
```

This defaults to an `Always<Substring.UTF8View, Void>` parser. A small win, but friendlier.

Second, and more substantially, it adds `buildExpression`s to both `ParserBuilder` and `OneOfBuilder`, defined such that when a `Substring` parser is encountered, it automatically converts it to a `Substring.UTF8View` parser by wrapping it in `FromSubstring`.

This allows you to work with parsers on either layer freely without needing to explicitly use `FromUTF8` or `FromSubstring`:

```swift
let parser = Parse {
  "caf".utf8  // parse quickly from UTF-8
  "é"         // parse all representations of é
}
```

This change also allows us to simplify a bunch of parsers. We can get rid of a bunch of interfaces that were there to simply wrap a parser in a `FromSubstring` (`Int.parser()`, `Double.parser()`, etc.), and we can get rid of an extra generic on parsers that only needed them to move between the parser's input type and the underlying bytes (`Whitespace`, `Digits`, etc.), and a bunch of simple parsers that were previously ambiguous now compile.

For example, @haikusw and @andreweades have [pointed out](https://github.com/pointfreeco/swift-parsing/discussions/155) that library newcomers quickly meet compiler error walls when first dabbling. Simple parsers where the `Input` is not known currently fail to compile:

```swift
Parse { // 🛑 Type of expression is ambiguous without more context
  Int.parser()
}

Parse { // 🛑 Type of expression is ambiguous without more context
  Whitespace()
}
```

And the only workaround thus far has been to make the input explicit, which is not ideal:

```swift
Parse {
  Int.parser(of: Substring.self)
}
// or
Parse {
  ""
  Int.parser()
}
```

But with this PR's changes these simple cases now compile just fine:

```swift
Parse {
  Int.parser()
}
Parse {
  Whitespace()
}
```

While all of these results are promising, it does force you to rethink what _kind_ of a parser a parser is. It's no longer correct to look at a `Parse` block and think "this is a substring parser" or "this is a UTF-8 parser". Instead, it's a UTF-8 parser by default (unless you're working with an entirely different input type).

Before, it was common to work on the substring level and let the library automatically dip down into UTF-8 where appropriate, but this PR kind of "inverts" things. The end call sight should look the same, though (`parser.parse(string)`), so we're not sure if this change is negative. (We could make the default layer `Substring` instead, and `buildExpression` could automatically wrap UTF-8 parsers in `FromUTF8`, but we were worried this would negatively impact performance...this may be worth actually benchmarking, though, as it's probably a slightly better end-user experience.)

This change is potentially quite impactful, so we'd like to measure how it affects others before merging. I'd like to tag a few more active library users to get their opinion on the change, and maybe see if it negatively impacts any of their projects:

- @finestructure
- @iampatbrown
- @MaxDesiatov
- @randomeizer 
- @tgrapperon