### PR TITLE
Fix overflow when comparing non-alphabetical chars

### DIFF
--- a/Sources/Parsing/ParserPrinters/Float.swift
+++ b/Sources/Parsing/ParserPrinters/Float.swift
@@ -155,7 +155,7 @@ extension Collection where SubSequence == Self, Element == UTF8.CodeUnit {
   @inline(__always)
   func caseInsensitiveElementsEqualLowercase<S: Sequence>(_ other: S) -> Bool
   where S.Element == Element {
-    self.elementsEqual(other, by: { $0 == $1 || $0 + 32 == $1 })
+    self.elementsEqual(other, by: { $0 == $1 || ((65...90).contains($0) && $0 + 32 == $1) })
   }
 }
 


### PR DESCRIPTION
This should fix #199.
The char range is checked to be in [A-Z] (that is `65...90`) before trying to lowercase the char by adding 32. 
This prevents going beyond `UInt8.max` by mistake.
I added a test that passed, but I removed it as it was only testing some internal method implementation.