### PR TITLE
Add SPI DocC support

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -7,3 +7,4 @@ builder:
     scheme: Parsing
   - platform: watchos
     scheme: Parsing_watchOS
+  - documentation_targets: [Parsing]

--- a/Package.swift
+++ b/Package.swift
@@ -59,3 +59,10 @@ let package = Package(
     ),
   ]
 )
+
+#if swift(>=5.6)
+  // Add the documentation compiler plugin if possible
+  package.dependencies.append(
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+  )
+#endif


### PR DESCRIPTION
Steps from https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/
