### PR TITLE
Add CheckTaskCancellation

### DIFF
--- a/Sources/Parsing/ParserPrinters/CheckTaskCancellation.swift
+++ b/Sources/Parsing/ParserPrinters/CheckTaskCancellation.swift
@@ -1,0 +1,54 @@
+/// A trivial parser that fails if the parent task is cancelled.
+///
+/// Parsing can be a long-running procedure. For this reason, you may want to abord the execution of
+/// a parser if its parent task is cancelled. When you compose parsers using a ``ParserBuilder``,
+/// you can insert this trivial parser before a potentially time-consuming sequence of parsers to
+/// abord processing it in any case the parent task is cancelled, and free the current thread. For
+/// example:
+///
+/// ```swift
+/// let parser = Parser {
+///   Many {
+///     CheckTaskCancellation()
+///     csvLineParser
+///   }
+/// }
+/// ```
+///
+/// This parser's sole purpose is to stop processing if it is evaluated when the parent task is
+/// cancelled. It doesn't affect parsing or printing results.
+///
+/// - Throws: This parser throws a `CancellationError` if the parent task is cancelled.
+public struct CheckTaskCancellation<Input>: ParserPrinter {
+  /// Construct a parser that runs the next parsers only if the parent task is not cancelled.
+  @inlinable
+  public init() {}
+
+  @inlinable
+  func checkTaskCancellationIfNeeded() throws {
+    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+      #if canImport(_Concurrency) && compiler(>=5.5.2)
+      try Task.checkCancellation()
+      #endif
+    }
+  }
+
+  @inlinable
+  public func parse(_ input: inout Input) throws {
+    try checkTaskCancellationIfNeeded()
+  }
+  @inlinable
+  public func print(_ output: Void, into input: inout Input) throws {
+    try checkTaskCancellationIfNeeded()
+  }
+}
+
+extension CheckTaskCancellation where Input == Substring {
+  @inlinable
+  public init() {}
+}
+
+extension CheckTaskCancellation where Input == Substring.UTF8View {
+  @inlinable
+  public init() {}
+}

--- a/Sources/Parsing/ParserPrinters/CheckTaskCancellation.swift
+++ b/Sources/Parsing/ParserPrinters/CheckTaskCancellation.swift
@@ -1,9 +1,9 @@
-/// A trivial parser that fails if the parent task is cancelled.
+/// A trivial parser that fails if the parent task is canceled.
 ///
 /// Parsing can be a long-running procedure. For this reason, you may want to abord the execution of
-/// a parser if its parent task is cancelled. When you compose parsers using a ``ParserBuilder``,
+/// a parser if its parent task is canceled. When you compose parsers using a ``ParserBuilder``,
 /// you can insert this trivial parser before a potentially time-consuming sequence of parsers to
-/// abord processing it in any case the parent task is cancelled, and free the current thread. For
+/// abord processing it in any case the parent task is canceled, and free the current thread. For
 /// example:
 ///
 /// ```swift
@@ -16,11 +16,11 @@
 /// ```
 ///
 /// This parser's sole purpose is to stop processing if it is evaluated when the parent task is
-/// cancelled. It doesn't affect parsing or printing results.
+/// canceled. It doesn't affect parsing or printing results.
 ///
-/// - Throws: This parser throws a `CancellationError` if the parent task is cancelled.
+/// - Throws: This parser throws a `CancellationError` if the parent task is canceled.
 public struct CheckTaskCancellation<Input>: ParserPrinter {
-  /// Construct a parser that runs the next parsers only if the parent task is not cancelled.
+  /// Construct a parser that runs the next parsers only if the parent task is not canceled.
   @inlinable
   public init() {}
 

--- a/Tests/ParsingTests/CheckTaskCancellationTests.swift
+++ b/Tests/ParsingTests/CheckTaskCancellationTests.swift
@@ -14,12 +14,12 @@ final class CheckTaskCancellationTests: XCTestCase {
 
     let count = 1_000_000
 
-    let task = Task { () -> [Int] in 
+    let task = Task { () -> [Int] in
       var values = Array(repeating: "1", count: count).joined(separator: ",")[...]
       return try parser.parse(&values)
     }
     // We let the task run for a little while before canceling it:
-    try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
+    try await Task.sleep(nanoseconds: 100_000_000)
     task.cancel()
     // The parser shouldn't have had the time to parse all the digits, and should have stopped
     // where it was was when the task was canceled:

--- a/Tests/ParsingTests/CheckTaskCancellationTests.swift
+++ b/Tests/ParsingTests/CheckTaskCancellationTests.swift
@@ -1,9 +1,9 @@
 import Parsing
 import XCTest
 
+#if canImport(_Concurrency) && compiler(>=5.6)
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *)
 final class CheckTaskCancellationTests: XCTestCase {
-  #if canImport(_Concurrency) && compiler(>=5.5.2)
   func testCheckClassCancellation() async throws {
     let parser = Many {
       CheckTaskCancellation()
@@ -26,5 +26,5 @@ final class CheckTaskCancellationTests: XCTestCase {
     let result = try await task.value
     XCTAssert(result.count < count)
   }
-  #endif
 }
+#endif

--- a/Tests/ParsingTests/CheckTaskCancellationTests.swift
+++ b/Tests/ParsingTests/CheckTaskCancellationTests.swift
@@ -19,7 +19,7 @@ final class CheckTaskCancellationTests: XCTestCase {
       return try parser.parse(&values)
     }
     // We let the task run for a little while before canceling it:
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await Task.sleep(nanoseconds: 50_000_000)
     task.cancel()
     // The parser shouldn't have had the time to parse all the digits, and should have stopped
     // where it was was when the task was canceled:

--- a/Tests/ParsingTests/CheckTaskCancellationTests.swift
+++ b/Tests/ParsingTests/CheckTaskCancellationTests.swift
@@ -1,20 +1,19 @@
 import Parsing
 import XCTest
-  
+
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *)
 final class CheckTaskCancellationTests: XCTestCase {
   #if canImport(_Concurrency) && compiler(>=5.5.2)
   func testCheckClassCancellation() async throws {
-    let parser = Parse {
-      Many {
-        CheckTaskCancellation()
-        Digits(1)
-      } separator: {
-        ","
-      }
+    let parser = Many {
+      CheckTaskCancellation()
+      Digits(1)
+    } separator: {
+      ","
     }
+
     let count = 1_000_000
-    
+
     let task = Task {
       var values = Array(repeating: "1", count: count).joined(separator: ",")[...]
       return try parser.parse(&values)
@@ -25,6 +24,7 @@ final class CheckTaskCancellationTests: XCTestCase {
     // The parser shouldn't have had the time to parse all the digits, and should have stopped
     // where it was was when the task was cancelled:
     let result = try await task.value
+    XCTAssert(result.count > 0)
     XCTAssert(result.count < count)
   }
   #endif

--- a/Tests/ParsingTests/CheckTaskCancellationTests.swift
+++ b/Tests/ParsingTests/CheckTaskCancellationTests.swift
@@ -24,7 +24,6 @@ final class CheckTaskCancellationTests: XCTestCase {
     // The parser shouldn't have had the time to parse all the digits, and should have stopped
     // where it was was when the task was canceled:
     let result = try await task.value
-    XCTAssert(result.count > 0)
     XCTAssert(result.count < count)
   }
   #endif

--- a/Tests/ParsingTests/CheckTaskCancellationTests.swift
+++ b/Tests/ParsingTests/CheckTaskCancellationTests.swift
@@ -1,0 +1,31 @@
+import Parsing
+import XCTest
+  
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *)
+final class CheckTaskCancellationTests: XCTestCase {
+  #if canImport(_Concurrency) && compiler(>=5.5.2)
+  func testCheckClassCancellation() async throws {
+    let parser = Parse {
+      Many {
+        CheckTaskCancellation()
+        Digits(1)
+      } separator: {
+        ","
+      }
+    }
+    let count = 1_000_000
+    
+    let task = Task {
+      var values = Array(repeating: "1", count: count).joined(separator: ",")[...]
+      return try parser.parse(&values)
+    }
+    // We let the task run for a little while before cancelling it:
+    try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
+    task.cancel()
+    // The parser shouldn't have had the time to parse all the digits, and should have stopped
+    // where it was was when the task was cancelled:
+    let result = try await task.value
+    XCTAssert(result.count < count)
+  }
+  #endif
+}

--- a/Tests/ParsingTests/CheckTaskCancellationTests.swift
+++ b/Tests/ParsingTests/CheckTaskCancellationTests.swift
@@ -18,11 +18,11 @@ final class CheckTaskCancellationTests: XCTestCase {
       var values = Array(repeating: "1", count: count).joined(separator: ",")[...]
       return try parser.parse(&values)
     }
-    // We let the task run for a little while before cancelling it:
+    // We let the task run for a little while before canceling it:
     try await Task.sleep(nanoseconds: NSEC_PER_SEC / 10)
     task.cancel()
     // The parser shouldn't have had the time to parse all the digits, and should have stopped
-    // where it was was when the task was cancelled:
+    // where it was was when the task was canceled:
     let result = try await task.value
     XCTAssert(result.count > 0)
     XCTAssert(result.count < count)

--- a/Tests/ParsingTests/CheckTaskCancellationTests.swift
+++ b/Tests/ParsingTests/CheckTaskCancellationTests.swift
@@ -14,7 +14,7 @@ final class CheckTaskCancellationTests: XCTestCase {
 
     let count = 1_000_000
 
-    let task = Task {
+    let task = Task { () -> [Int] in 
       var values = Array(repeating: "1", count: count).joined(separator: ",")[...]
       return try parser.parse(&values)
     }


### PR DESCRIPTION
Following the discussion #221, this PR proposes to add a trivial `CheckTaskCancellation` parser/printer that can early-out parsing if the parent task is canceled. It is used as one would use `try Task.checkCancellation()`, that is before a potentially lengthy operation:
```swift
Many {
  CheckTaskCancellation()
  Parse {…}
}
```
This gives the user the possibility to perform these checks where and when it is relevant.

I find the enclosing or fluent alternative discussed in #221 more difficult to understand because of the parser they should be applied to. Users using `Tasks` should likely be familiar with this PR's construct.

This doesn't fix the issue of parsing 100 millions integers. In this case, we would only want to perform the checks every 10000 integers for example, but the `CheckTaskCancellation` style doesn't allow this. It is probable that we can build something that does this with existing combinators. I had a potential implementation that made `CheckTaskCancellation` a class with a counter, and some API like `CheckTaskCancellation(every: 10000)`, but I was worried about the added complexity for the user (this situation only occurs in a `Many`, but the argument is there all the time and can be used where it doesn't make sense). And there was an issue with making it `Sendable`, locks & performance. So for now, I have no solution to propose for this configuration.

In order to test it, we generate a very long string of "1,1,1,…" and ask a `Many` parser to process it in a `Task`. Quickly after the beginning of the execution, we cancel the `Task` and check how much it processed. Since the parsing was aborted, the expected count should be lower than the input's size. If we remove the check, parsing continues for a few seconds and all the input is processed. On my machine, it passes in ~0.1s, parsing ~1/10th of the input, and fails in ~4s. ~This gives some room ahead and shouldn't be too flaky~ *[Downloading Xcode from CI to check what's going on]*. There is maybe a better way to test it.

This makes me wonder if we should backtrack when we exit processing, because we have a parser that threw and consumed the input.