### PR TITLE
Make PipeEnd a ParserPrinter

### DIFF
--- a/Sources/Parsing/ParserPrinters/Pipe.swift
+++ b/Sources/Parsing/ParserPrinters/Pipe.swift
@@ -97,3 +97,23 @@ where
     try self.upstream.print(self.downstream.print(output), into: &input)
   }
 }
+
+extension Parsers.PipeEnd: ParserPrinter {
+  @inlinable
+  public func print(_ output: (), into input: inout Input) throws {
+    guard input.isEmpty else {
+      let description = describe(input).map { "\n\n\($0.debugDescription)" } ?? ""
+      throw PrintingError.failed(
+        summary: """
+          round-trip expectation failed
+
+          A "PipeEnd" parser-printer expected no more input, but more was printed.\(description)
+
+          During a round-trip, the "PipeEnd" parser-printer would have failed to parse at this \
+          remaining input.
+          """,
+        input: input
+      )
+    }
+  }
+}

--- a/Sources/Parsing/ParserPrinters/Pipe.swift
+++ b/Sources/Parsing/ParserPrinters/Pipe.swift
@@ -107,9 +107,9 @@ extension Parsers.PipeEnd: ParserPrinter {
         summary: """
           round-trip expectation failed
 
-          A "PipeEnd" parser-printer expected no more input, but more was printed.\(description)
+          A piped parser-printer expected no more input, but more was printed.\(description)
 
-          During a round-trip, the "PipeEnd" parser-printer would have failed to parse at this \
+          During a round-trip, the piped parser-printer would have failed to parse at this \
           remaining input.
           """,
         input: input

--- a/Tests/ParsingTests/PipeEndTests.swift
+++ b/Tests/ParsingTests/PipeEndTests.swift
@@ -49,18 +49,4 @@ final class PipeEndTests: XCTestCase {
     }
     XCTAssertEqual(input, "Hello, world!"[...])
   }
-
-  func testTrailingWhitespace() {
-    XCTAssertThrowsError(try Int.parser().parse("123   ")) { error in
-      XCTAssertEqual(
-        """
-        error: unexpected input
-         --> input:1:4
-        1 | 123␣␣␣
-          |    ^ expected end of input
-        """,
-        "\(error)"
-      )
-    }
-  }
 }

--- a/Tests/ParsingTests/PipeEndTests.swift
+++ b/Tests/ParsingTests/PipeEndTests.swift
@@ -37,11 +37,11 @@ final class PipeEndTests: XCTestCase {
         """
         error: round-trip expectation failed
 
-        A "PipeEnd" parser-printer expected no more input, but more was printed.
+        A piped parser-printer expected no more input, but more was printed.
 
         "Hello, world!"
 
-        During a round-trip, the "PipeEnd" parser-printer would have failed to parse at this \
+        During a round-trip, the piped parser-printer would have failed to parse at this \
         remaining input.
         """,
         "\(error)"

--- a/Tests/ParsingTests/PipeEndTests.swift
+++ b/Tests/ParsingTests/PipeEndTests.swift
@@ -1,0 +1,66 @@
+@testable import Parsing
+import XCTest
+
+final class PipeEndTests: XCTestCase {
+  func testSuccess() {
+    var input = ""[...]
+      XCTAssertNoThrow(try Parsers.PipeEnd().parse(&input))
+    XCTAssertEqual("", input)
+  }
+
+  func testFailure() {
+    var input = "Hello, world!"[...]
+      XCTAssertThrowsError(try Parsers.PipeEnd().parse(&input)) { error in
+      XCTAssertEqual(
+        """
+        error: unexpected input
+         --> input:1:1-13
+        1 | Hello, world!
+          | ^^^^^^^^^^^^^ expected end of pipe
+        """,
+        "\(error)"
+      )
+    }
+    XCTAssertEqual("Hello, world!", input)
+  }
+
+  func testPrintSuccess() {
+    var input = ""[...]
+      XCTAssertNoThrow(try Parsers.PipeEnd().print(into: &input))
+    XCTAssertEqual(input, ""[...])
+  }
+
+  func testPrintFailure() {
+    var input = "Hello, world!"[...]
+      XCTAssertThrowsError(try Parsers.PipeEnd().print(into: &input)) { error in
+      XCTAssertEqual(
+        """
+        error: round-trip expectation failed
+
+        A "PipeEnd" parser-printer expected no more input, but more was printed.
+
+        "Hello, world!"
+
+        During a round-trip, the "PipeEnd" parser-printer would have failed to parse at this \
+        remaining input.
+        """,
+        "\(error)"
+      )
+    }
+    XCTAssertEqual(input, "Hello, world!"[...])
+  }
+
+  func testTrailingWhitespace() {
+    XCTAssertThrowsError(try Int.parser().parse("123   ")) { error in
+      XCTAssertEqual(
+        """
+        error: unexpected input
+         --> input:1:4
+        1 | 123␣␣␣
+          |    ^ expected end of input
+        """,
+        "\(error)"
+      )
+    }
+  }
+}


### PR DESCRIPTION
Added `ParserPrinter` conformance to the `PipeEnd` parser as discussed in #226 