### PR TITLE
[Feat] Add support for PrefixUntil

### DIFF
--- a/Sources/Parsing/ParserPrinters/PrefixUntil.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixUntil.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// A parser that consumes a subsequence from the beginning of its input up to a given parser succeed.
+///
+/// This parser behave a lot like `PrefixUpTo` but it can be slower because it can use a parser instead of
+/// a static string and consume and return input up to a particular parser succeed.
+///
+/// If provided with a string that correspond to the begining of the parser it will be almost as fast as `PrefixUpTo` in most cases. The only case where it will be slow when providing a string is when there is a lot of false positive aka pattern that look like what the parser should valid but are not valid.
+///
+/// ```swift
+/// let separatorParser = Parse {
+///   "["
+///   Int.parser()
+///   Optionally {
+///     ";"
+///     Int.parser()
+///   }
+///   "m"
+/// }
+///
+/// let lineParser = PrefixUntil { separatorParser }
+///
+/// var input = "Hello[31mworld[30m\n"[...]
+/// try line.parse(&input)  // "Hello"
+/// input                   // "[31mworld[30m\n"
+/// ```
+///
+/// - Tip: This is 15x slower than `PrefixUpTo` so use it only where a dynamic limit is needed caution.
+public struct PrefixUntil<Input: Collection, Upstream: Parser>: Parser where Input.SubSequence == Input, Upstream.Input == Input {
+  
+  public let upstream: Upstream
+  public let possibleMatch: Input?
+  public let areEquivalent: (Input.Element, Input.Element) -> Bool
+  
+  @inlinable
+  public init(
+    _ possibleMatch: Input? = nil,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool,
+    @ParserBuilder _ build: () -> Upstream) {
+      self.upstream = build()
+      self.possibleMatch = possibleMatch
+      self.areEquivalent = areEquivalent
+    }
+  
+  @inlinable
+  public func fastPath(_ input: inout Input) throws -> Input {
+    guard let possibleMatch = self.possibleMatch else { return input }
+    guard let first = possibleMatch.first else { return possibleMatch }
+    let count = possibleMatch.count
+    let original = input
+    
+    while let index = input.firstIndex(where: { self.areEquivalent(first, $0) }) {
+      input = input[index...]
+      if input.count >= count,
+        zip(input[index...], possibleMatch).allSatisfy(self.areEquivalent)
+      {
+        let outputSlow = try slowPath(&input)
+        if outputSlow.count == 0 { return original[..<index] }
+        return outputSlow
+      }
+      input.removeFirst()
+    }
+    input.removeFirst(original.count)
+    return original
+  }
+  
+  @inlinable
+  public func slowPath(_ input: inout Input) throws -> Input {
+    let original = input
+    var testInput = input
+    var index = input.startIndex
+    var hasParsed = (try? self.upstream.parse(&testInput)) != nil
+
+    while hasParsed == false && index != testInput.endIndex {
+      testInput.removeFirst()
+      index = testInput.startIndex
+      hasParsed = (try? self.upstream.parse(&testInput)) != nil
+    }
+    
+    let lenght = original[..<index].count
+    input.removeFirst(lenght)
+    return original[..<index]
+  }
+  
+  @inlinable
+  public func parse(_ input: inout Input) throws -> Input {
+    guard !input.isEmpty
+    else { throw ParsingError.expectedInput("a non-empty input", at: input) }
+    guard let possibleMatch = self.possibleMatch
+    else { return try slowPath(&input)  }
+    return try fastPath(&input)
+  }
+}
+
+extension PrefixUntil where Input.Element: Equatable {
+  @inlinable
+  public init(@ParserBuilder _ build: () -> Upstream) {
+    self.init(nil, by: ==, build)
+  }
+}
+
+extension PrefixUntil where Input == Substring {
+  @_disfavoredOverload
+  @inlinable
+  public init(_ possiblePrefix: String, @ParserBuilder _ build: () -> Upstream) {
+    self.init(possiblePrefix[...], by: ==, build)
+  }
+}
+
+extension PrefixUntil where Input == Substring.UTF8View {
+  @_disfavoredOverload
+  @inlinable
+  public init(_ possibleMatch: String.UTF8View, @ParserBuilder _ build: () -> Upstream) {
+    self.init(String(possibleMatch)[...].utf8, by: ==, build)
+  }
+}
+
+extension Parsers {
+  public typealias PrefixUntil = Parsing.PrefixUntil  // NB: Convenience type alias for discovery
+}

--- a/Sources/Parsing/ParserPrinters/PrefixUntil.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixUntil.swift
@@ -18,7 +18,7 @@ import Foundation
 ///   "m"
 /// }
 ///
-/// let lineParser = PrefixUntil { separatorParser }
+/// let lineParser = PrefixUntil("[") { separatorParser }
 ///
 /// var input = "Hello[31mworld[30m\n"[...]
 /// try line.parse(&input)  // "Hello"

--- a/Sources/swift-parsing-benchmark/PrefixUntil.swift
+++ b/Sources/swift-parsing-benchmark/PrefixUntil.swift
@@ -1,0 +1,38 @@
+import Benchmark
+import Foundation
+import Parsing
+
+/// This benchmarks the performance of `PrefixUntil` against `PrefixUpTo` for simple parsing.
+let prefixUntilSuite = BenchmarkSuite(name: "PrefixUntil") { suite in
+  let input = String(repeating: ".", count: 10_000) + "Hello, world!"
+
+  do {
+    var output: Substring!
+    suite.benchmark("Parser: PrefixUpTo") {
+      var input = input[...]
+      output = try PrefixUpTo("Hello").parse(&input)
+    } tearDown: {
+      precondition(output.count == 10_000)
+    }
+  }
+
+  do {
+    var output: Substring!
+    suite.benchmark("Parser: PrefixUntil - FastPath") {
+      var input = input[...]
+      output = try PrefixUntil("H") { "Hello" }.parse(&input)
+    } tearDown: {
+      precondition(output.count == 10_000)
+    }
+  }
+
+  do {
+    var output: Substring!
+    suite.benchmark("Parser: PrefixUntil - SlowPath") {
+      var input = input[...]
+      output = try PrefixUntil { "Hello" }.parse(&input)
+    } tearDown: {
+      precondition(output.count == 10_000)
+    }
+  }
+}

--- a/Sources/swift-parsing-benchmark/PrefixUntil.swift
+++ b/Sources/swift-parsing-benchmark/PrefixUntil.swift
@@ -8,7 +8,7 @@ let prefixUntilSuite = BenchmarkSuite(name: "PrefixUntil") { suite in
 
   do {
     var output: Substring!
-    suite.benchmark("Parser: PrefixUpTo") {
+    suite.benchmark("PrefixUpTo") {
       var input = input[...]
       output = try PrefixUpTo("Hello").parse(&input)
     } tearDown: {
@@ -18,7 +18,7 @@ let prefixUntilSuite = BenchmarkSuite(name: "PrefixUntil") { suite in
 
   do {
     var output: Substring!
-    suite.benchmark("Parser: PrefixUntil - FastPath") {
+    suite.benchmark("PrefixUntil / FastPath") {
       var input = input[...]
       output = try PrefixUntil("H") { "Hello" }.parse(&input)
     } tearDown: {
@@ -28,11 +28,90 @@ let prefixUntilSuite = BenchmarkSuite(name: "PrefixUntil") { suite in
 
   do {
     var output: Substring!
-    suite.benchmark("Parser: PrefixUntil - SlowPath") {
+    suite.benchmark("PrefixUntil / SlowPath") {
       var input = input[...]
       output = try PrefixUntil { "Hello" }.parse(&input)
     } tearDown: {
       precondition(output.count == 10_000)
+    }
+  }
+
+  struct Attribute: Equatable {
+    public let at1: Int
+    public let at2: Int?
+  }
+
+  struct ParsedText: Equatable {
+    var attribute: Attribute?
+    var text: String
+  }
+
+  do {
+    var output: [ParsedText]!
+    suite.benchmark("PrefixUntil / FastPath / Complex") {
+      
+      let fontModifier = Parse {
+        "|"
+        Int.parser()
+        Optionally {
+          ":"
+          Int.parser()
+        }
+        "🌶"
+      }.map { Attribute(at1: $0.0, at2: $0.1) }
+
+      let textWithAttributes = Parse {
+        Peek { Prefix<Substring>(1) }
+        Optionally { fontModifier }
+        Optionally { PrefixUntil("|") { fontModifier }.map(String.init) }
+      }.map { ParsedText(attribute: $0.0, text: $0.1 ?? "") }
+
+      let mainParser = Many(1...) {
+        textWithAttributes
+      }
+      var input = String(repeating: ".", count: 10_000) + "|36🌶INFO|0🌶|08:45:33| |33:1🌶ci runs in Secret Filtering mode|0🌶 "
+      var complexInput = input[...]
+      output = try mainParser.parse(&complexInput)
+    } tearDown: {
+      precondition(ParsedText(attribute: Attribute(at1: 36, at2: nil), text: "INFO") == output[1])
+      precondition(ParsedText(attribute: Attribute(at1: 0, at2: nil), text: "|08:45:33| ") == output[2])
+      precondition(ParsedText(attribute: Attribute(at1: 33, at2: 1), text: "ci runs in Secret Filtering mode") == output[3])
+      precondition(ParsedText(attribute: Attribute(at1: 0, at2: nil), text: " ") == output[4])
+    }
+  }
+
+
+  do {
+    var output: [ParsedText]!
+    suite.benchmark("PrefixUntil / SlowPath / Complex") {
+      
+      let fontModifier = Parse {
+        "|"
+        Int.parser()
+        Optionally {
+          ":"
+          Int.parser()
+        }
+        "🌶"
+      }.map { Attribute(at1: $0.0, at2: $0.1) }
+
+      let textWithAttributes = Parse {
+        Peek { Prefix<Substring>(1) }
+        Optionally { fontModifier }
+        Optionally { PrefixUntil { fontModifier }.map(String.init) }
+      }.map { ParsedText(attribute: $0.0, text: $0.1 ?? "") }
+
+      let mainParser = Many(1...) {
+        textWithAttributes
+      }
+      var input = String(repeating: ".", count: 10_000) + "|36🌶INFO|0🌶|08:45:33| |33:1🌶ci runs in Secret Filtering mode|0🌶 "
+      var complexInput = input[...]
+      output = try mainParser.parse(&complexInput)
+    } tearDown: {
+      precondition(ParsedText(attribute: Attribute(at1: 36, at2: nil), text: "INFO") == output[1])
+      precondition(ParsedText(attribute: Attribute(at1: 0, at2: nil), text: "|08:45:33| ") == output[2])
+      precondition(ParsedText(attribute: Attribute(at1: 33, at2: 1), text: "ci runs in Secret Filtering mode") == output[3])
+      precondition(ParsedText(attribute: Attribute(at1: 0, at2: nil), text: " ") == output[4])
     }
   }
 }

--- a/Sources/swift-parsing-benchmark/main.swift
+++ b/Sources/swift-parsing-benchmark/main.swift
@@ -14,6 +14,7 @@ Benchmark.main(
     jsonSuite,
     numericsSuite,
     prefixUpToSuite,
+    prefixUntilSuite,
     raceSuite,
     readmeExampleSuite,
     stringAbstractionsSuite,

--- a/Tests/ParsingTests/PrefixUntilTests.swift
+++ b/Tests/ParsingTests/PrefixUntilTests.swift
@@ -1,0 +1,108 @@
+import Parsing
+import XCTest
+
+struct Attribute: Equatable {
+  public let at1: Int
+  public let at2: Int?
+}
+
+struct ParsedText: Equatable {
+  var attribute: Attribute?
+  var text: String
+}
+
+final class PrefixUntilTests: XCTestCase {
+  func testSuccess() {
+    var input = "Hello,world, 42!"[...]
+    XCTAssertEqual("Hello,world", try PrefixUntil(", ") { ", " }.parse(&input))
+    XCTAssertEqual(", 42!", input)
+  }
+  
+  func testSuccessIsEmpty() {
+    var input = "Hello, world!"[...]
+    XCTAssertEqual("", try PrefixUntil("") { "" }.parse(&input))
+    XCTAssertEqual("Hello, world!", input)
+  }
+  
+  func testMoreComplexExempleSlowPath() {
+    let fontModifier = Parse {
+      "|"
+      Int.parser()
+      Optionally {
+        ":"
+        Int.parser()
+      }
+      "🌶"
+    }.map { Attribute(at1: $0.0, at2: $0.1) }
+
+    let textWithAttributes = Parse {
+      Peek { Prefix<Substring>(1) }
+      Optionally { fontModifier }
+      Optionally { PrefixUntil { fontModifier }.map(String.init) }
+    }.map { ParsedText(attribute: $0.0, text: $0.1 ?? "") }
+
+    let mainParser = Many(1...) {
+      textWithAttributes
+    }
+    var input = "|36🌶INFO|0🌶|08:45:33| |33:1🌶ci runs in Secret Filtering mode|0🌶 "[...]
+    XCTAssertEqual([
+      ParsedText(attribute: Attribute(at1: 36, at2: nil), text: "INFO"),
+      ParsedText(attribute: Attribute(at1: 0, at2: nil), text: "|08:45:33| "),
+      ParsedText(attribute: Attribute(at1: 33, at2: 1), text: "ci runs in Secret Filtering mode"),
+      ParsedText(attribute: Attribute(at1: 0, at2: nil), text: " "),
+    ], try mainParser.parse(&input))
+    XCTAssertEqual("", input)
+  }
+
+  func testMoreComplexExempleFastPath() {
+
+    let fontModifier = Parse {
+      "|"
+      Int.parser()
+      Optionally {
+        ":"
+        Int.parser()
+      }
+      "🌶"
+    }.map { Attribute(at1: $0.0, at2: $0.1) }
+
+    let textWithAttributes = Parse {
+      Peek { Prefix<Substring>(1) }
+      Optionally { fontModifier }
+      Optionally { PrefixUntil("|") { fontModifier }.map(String.init) }
+    }.map { ParsedText(attribute: $0.0, text: $0.1 ?? "") }
+
+    let mainParser = Many(1...) {
+      textWithAttributes
+    }
+    var input = "|36🌶INFO|0🌶|08:45:33| |33:1🌶ci runs in Secret Filtering mode|0🌶 "[...]
+    XCTAssertEqual([
+      ParsedText(attribute: Attribute(at1: 36, at2: nil), text: "INFO"),
+      ParsedText(attribute: Attribute(at1: 0, at2: nil), text: "|08:45:33| "),
+      ParsedText(attribute: Attribute(at1: 33, at2: 1), text: "ci runs in Secret Filtering mode"),
+      ParsedText(attribute: Attribute(at1: 0, at2: nil), text: " "),
+    ], try mainParser.parse(&input))
+    XCTAssertEqual("", input)
+  }
+
+  func testFailureIsEmpty() {
+    var input = ""[...]
+    XCTAssertThrowsError(try PrefixUntil(", ") { ", " }.parse(&input)) { error in
+      XCTAssertEqual(
+        """
+        error: unexpected input
+         --> input:1:1
+        1 |
+          | ^ expected a non-empty input
+        """,
+        "\(error)"
+      )
+    }
+    XCTAssertEqual("", input)
+  }
+  
+  func testConsumeWholeString() {
+    var input = "Hello world!"[...]
+    XCTAssertEqual("Hello world!", try PrefixUntil(", ") { ", " }.parse(&input))
+  }
+}

--- a/Tests/ParsingTests/PrefixUntilTests.swift
+++ b/Tests/ParsingTests/PrefixUntilTests.swift
@@ -1,16 +1,6 @@
 import Parsing
 import XCTest
 
-struct Attribute: Equatable {
-  public let at1: Int
-  public let at2: Int?
-}
-
-struct ParsedText: Equatable {
-  var attribute: Attribute?
-  var text: String
-}
-
 final class PrefixUntilTests: XCTestCase {
   func testSuccess() {
     var input = "Hello,world, 42!"[...]
@@ -104,5 +94,15 @@ final class PrefixUntilTests: XCTestCase {
   func testConsumeWholeString() {
     var input = "Hello world!"[...]
     XCTAssertEqual("Hello world!", try PrefixUntil(", ") { ", " }.parse(&input))
+  }
+  
+  struct Attribute: Equatable {
+    public let at1: Int
+    public let at2: Int?
+  }
+
+  struct ParsedText: Equatable {
+    var attribute: Attribute?
+    var text: String
   }
 }


### PR DESCRIPTION
Hi,

This PR adds support for a parser `PrefixUntil` that behaves like `PrefixUpTo` in most cases but takes a parser too in order to validate a certain pattern.

`PrefixUntil` consumes a subsequence from the beginning of its input up to a given sequence of elements then run a parser to test them. In case of success, the prefix is returned. 

It have a fast path(🏎💨) and a slow path(🐌). The fast path is enable by providing the beginning of the parser as a string when the begining will be found it will try the real parser to confirm. The slow path consumes elements of a collection one by one until a given parser parser succeeds.

The fast path is a modified version of `PrefixUpTo` with a small twist to confirm a pattern with a parser.

`PrefixUntil` allows consuming input with a dynamic end. 

- [ ] At the moment it lack support for printing(and I have no idea how to do it if someone could help)

## Benchmark

It performs very well in most cases almost as fast as `PrefixUpTo`. On a more complex parsing challenge `FastPath` is still way faster than `SlowPath`.

```
name                                         time           std        iterations
---------------------------------------------------------------------------------
PrefixUntil.PrefixUpTo                        256875.000 ns ±  11.13 %       5191
PrefixUntil.PrefixUntil / FastPath            251291.000 ns ±  23.88 %       5554
PrefixUntil.PrefixUntil / SlowPath           4010916.000 ns ±   1.79 %        345
PrefixUntil.PrefixUntil / FastPath / Complex  425958.500 ns ±   1.76 %       3288
PrefixUntil.PrefixUntil / SlowPath / Complex 5709958.000 ns ±   2.31 %        237
```

# Links

https://github.com/pointfreeco/swift-parsing/discussions/228
https://github.com/pointfreeco/swift-parsing/discussions/223

Cheers,