### PR TITLE
Refine `StartsWith`, `PrefixUpTo` and `PrefixThrough` `Input` inference

### DIFF
--- a/Sources/Parsing/ParserPrinters/PrefixThrough.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixThrough.swift
@@ -87,7 +87,10 @@ extension PrefixThrough where Input.Element: Equatable {
 extension PrefixThrough where Input == Substring {
   @_disfavoredOverload
   @inlinable
-  public init(_ possibleMatch: String) {
+  public init(
+    _ possibleMatch: String,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)
+  ) {
     self.init(possibleMatch[...])
   }
 }
@@ -95,7 +98,10 @@ extension PrefixThrough where Input == Substring {
 extension PrefixThrough where Input == Substring.UTF8View {
   @_disfavoredOverload
   @inlinable
-  public init(_ possibleMatch: String.UTF8View) {
+  public init(
+    _ possibleMatch: String.UTF8View,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)
+  ) {
     self.init(String(possibleMatch)[...].utf8)
   }
 }

--- a/Sources/Parsing/ParserPrinters/PrefixUpTo.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixUpTo.swift
@@ -92,15 +92,21 @@ extension PrefixUpTo where Input.Element: Equatable {
 extension PrefixUpTo where Input == Substring {
   @_disfavoredOverload
   @inlinable
-  public init(_ possiblePrefix: String) {
-    self.init(possiblePrefix[...])
+  public init(
+    _ possibleMatch: String,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)
+  ) {
+    self.init(possibleMatch[...])
   }
 }
 
 extension PrefixUpTo where Input == Substring.UTF8View {
   @_disfavoredOverload
   @inlinable
-  public init(_ possibleMatch: String.UTF8View) {
+  public init(
+    _ possibleMatch: String.UTF8View,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)
+  ) {
     self.init(String(possibleMatch)[...].utf8)
   }
 }

--- a/Sources/Parsing/ParserPrinters/StartsWith.swift
+++ b/Sources/Parsing/ParserPrinters/StartsWith.swift
@@ -88,6 +88,26 @@ extension StartsWith where Input.Element: Equatable {
   }
 }
 
+extension StartsWith where Input == Substring {
+  @_disfavoredOverload
+  @inlinable
+  public init(
+    _ possiblePrefix: String,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)) {
+    self.init(possiblePrefix[...])
+  }
+}
+
+extension StartsWith where Input == Substring.UTF8View {
+  @_disfavoredOverload
+  @inlinable
+  public init(
+    _ possiblePrefix: String.UTF8View,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)) {
+    self.init(String(possiblePrefix)[...].utf8)
+  }
+}
+
 extension Parsers {
   public typealias StartsWith = Parsing.StartsWith  // NB: Convenience type alias for discovery
 }


### PR DESCRIPTION
As discussed in #235.
- `StartsWith`: Add new overloads, with exposed `by areEquivalent` defaulting to `==`.
- `PrefixUpTo` and `PrefixThrough`: Expose the `by areEquivalent` argument, defaulting to `==`.

As a result, the following compiles:
```swift
Parse {
  PrefixUpTo(".git") { $0.lowercased() == $1.lowercased() }
  StartsWith(".git") { $0.lowercased() == $1.lowercased() }
}
```
