### PR TITLE
Add minimum platform requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,12 @@ import PackageDescription
 
 let package = Package(
   name: "swift-parsing",
+  platforms: [
+    .iOS(.v13),
+    .macOS(.v10_15),
+    .tvOS(.v13),
+    .watchOS(.v6),
+  ],
   products: [
     .library(
       name: "Parsing",


### PR DESCRIPTION
Let's add some minimums to align with other projects, including XCTest Dynamic Overlay.

Folks that need to keep the less restrictive platforms may need to lock their dependencies as a result. While we're open to supporting older platforms, it comes with a maintenance burden, so we'd like to see a real need to do so first.
