### PR TITLE
Bring the coalescing operator `??` to parsers

### DIFF
--- a/Sources/Parsing/ParserPrinters/ReplaceError.swift
+++ b/Sources/Parsing/ParserPrinters/ReplaceError.swift
@@ -85,3 +85,19 @@ extension Parsers.ReplaceError: ParserPrinter where Upstream: ParserPrinter {
     }
   }
 }
+
+@inlinable
+public func ?? <Upstream: Parser>(upstream: Upstream, default: Upstream.Output)
+  -> Parsers.ReplaceError<Upstream>
+{
+  upstream.replaceError(with: `default`)
+}
+
+@inlinable
+public func ?? <Upstream: Parser, Wrapped>(upstream: Upstream, default: Upstream.Output)
+  -> Parsers.ReplaceError<Parsers.Filter<Upstream>>
+where Upstream.Output == Wrapped? {
+  upstream
+    .filter { $0 != nil }
+    .replaceError(with: `default`)
+}

--- a/Tests/ParsingTests/ReplaceErrorTests.swift
+++ b/Tests/ParsingTests/ReplaceErrorTests.swift
@@ -12,4 +12,46 @@ final class ReplaceErrorTests: XCTestCase {
       }.replaceError(with: 0).parse(&input))
     XCTAssertEqual("123", input)
   }
+  
+  func testCoalescingParser() {
+    var input = "abc"[...]
+    XCTAssertEqual(
+      "default",
+      Parse {
+        PrefixUpTo("123") ?? "default"
+      }.parse(&input))
+    XCTAssertEqual("abc", input)
+  }
+  
+  func testCoalescingNonNilOptionalParser() {
+    var input = "abc"[...]
+    let maybePrefix: PrefixUpTo<Substring>? = .init("123")
+    XCTAssertEqual(
+      "default",
+      Parse {
+        maybePrefix ?? "default"
+      }.parse(&input))
+    XCTAssertEqual("abc", input)
+  }
+  
+  func testCoalescingNilOptionalParser() {
+    var input = "abc"[...]
+    let maybePrefix: PrefixUpTo<Substring>? = nil
+    XCTAssertEqual(
+      "default",
+      Parse {
+        maybePrefix ?? "default"
+      }.parse(&input))
+    XCTAssertEqual("abc", input)
+  }
+  
+  func testCoalescingOptionallyParser() {
+    var input = "abc"[...]
+    XCTAssertEqual(
+      "default",
+      Parse {
+        Optionally { PrefixUpTo("123") } ?? "default"
+      }.parse(&input))
+    XCTAssertEqual("abc", input)
+  }
 }


### PR DESCRIPTION
Hello!
This PR adds two overloads for the nil-coalescing operator to sugar `.replaceError(with:)`. 
It should improve reachability of `ReplaceError` parsers that are very frequently needed.
 
If the left/upstream parser fails, it falls back with the right/default value. If `P<Output>` is some upstream parser and `default` an `Output` value, the overall parser always returns `default` when the upstream `P` fails in some way:
```swift
P<Int> ?? 1   P fails, parses 1
P<Int?> ?? 1  P fails, parses 1
P<Int>? ?? 1  P fails or is nil, parses 1
```
I think this is what users would naturally expect.

It shouldn't impact existing parsers.

We could maybe expand/update the documentation around `ReplaceError` or `Optionally`. I think we can also document these overloads if they appear in docc. I'll update this PR with more documentation commits, should it go further.