### PR TITLE
Allow match after `Prefix` with max count

### DIFF
--- a/Sources/Parsing/ParserPrinters/Prefix.swift
+++ b/Sources/Parsing/ParserPrinters/Prefix.swift
@@ -167,19 +167,21 @@ extension Prefix: ParserPrinter where Input: PrependableCollection {
           input: input
         )
       }
-      guard input.first.map(predicate) != true
-      else {
-        throw PrintingError.failed(
-          summary: """
-            round-trip expectation failed
+      if count != maximum {
+        guard input.first.map(predicate) != true
+        else {
+          throw PrintingError.failed(
+            summary: """
+              round-trip expectation failed
 
-            A "Prefix" parser's predicate satisfied the first element printed by the next printer.
+              A "Prefix" parser's predicate satisfied the first element printed by the next printer.
 
-            During a round-trip, the "Prefix" parser would have parsed this element, which means \
-            the data handed to the next printer is in an invalid state.
-            """,
-          input: input
-        )
+              During a round-trip, the "Prefix" parser would have parsed this element, which means \
+              the data handed to the next printer is in an invalid state.
+              """,
+            input: input
+          )
+        }
       }
     }
     input.prepend(contentsOf: output)

--- a/Tests/ParsingTests/PrefixTests.swift
+++ b/Tests/ParsingTests/PrefixTests.swift
@@ -107,4 +107,12 @@ final class PrefixTests: XCTestCase {
       )
     }
   }
+
+  func testPrintWithMaxCountAllowMatchingNextElement() {
+    let p = ParsePrint {
+      Prefix(3) { $0.isNumber }
+      First()
+    }
+    XCTAssertEqual("1230", try p.print(("123", "0")))
+  }
 }


### PR DESCRIPTION
The printing for the `Prefix` `ParserPrinter` fails whenever it detects that the next element printed matches its predicate. However, this should be allowed in the special case that the parser _has a maximum count_, and _the value to print has exactly that count_. This is because that would have stopped the parsing before the next element, regardless of whether it matches the predicate or not.