### PR TITLE
Fix typo in OneOfBuilder documentation

### DIFF
--- a/Sources/Parsing/Builders/OneOfBuilder.swift
+++ b/Sources/Parsing/Builders/OneOfBuilder.swift
@@ -29,9 +29,9 @@ public enum OneOfBuilder {
   ///   case member
   /// }
   ///
-  /// let roleParser = Parse {
+  /// let roleParser = OneOf {
   ///   for role in Role.allCases {
-  ///     status.rawValue.map { role }
+  ///     role.rawValue.map { role }
   ///   }
   /// }
   /// ```


### PR DESCRIPTION
Hello 👋  Hope all is well

The changes fix a small type for `OneOfBuilder.swift` documentation

I've took the example from [its tests](https://github.com/pointfreeco/swift-parsing/blob/main/Tests/ParsingTests/OneOfBuilderTests.swift)

```swift
final class OneOfBuilderTests: XCTestCase {
  func testBuildArray() {
    enum Role: String, CaseIterable, Equatable {
      case admin
      case guest
      case member
    }

    let parser = OneOf {
      for role in Role.allCases {
        role.rawValue.map { role }
      }
    }
    //...
```