### PR TITLE
Fix typo in OneOfMany documentation

### DIFF
--- a/Sources/Parsing/ParserPrinters/OneOfMany.swift
+++ b/Sources/Parsing/ParserPrinters/OneOfMany.swift
@@ -13,7 +13,7 @@ extension Parsers {
   ///
   /// let roleParser = OneOf {
   ///   for role in Role.allCases {
-  ///     status.rawValue.map { role }
+  ///     role.rawValue.map { role }
   ///   }
   /// }
   /// ```


### PR DESCRIPTION
Hello 👋 

The changes fix a small typo in `OneOfMany.swift` documentation

Sorry for missing it in [my previous PR](https://github.com/pointfreeco/swift-parsing/pull/257) 🙇 