### PR TITLE
Extend CaseIterableRawRepresentable to FixedWidthInteger

### DIFF
--- a/Sources/Parsing/ParserPrinters/CaseIterableRawRepresentable.swift
+++ b/Sources/Parsing/ParserPrinters/CaseIterableRawRepresentable.swift
@@ -1,4 +1,4 @@
-extension CaseIterable where Self: RawRepresentable, RawValue == Int {
+extension CaseIterable where Self: RawRepresentable, RawValue: FixedWidthInteger {
   /// A parser that consumes a case-iterable, raw representable value from the beginning of a
   /// collection of a substring.
   ///


### PR DESCRIPTION
#276

> Hi @ytyubox, good catch!
> 
> Rather than making the initializer public, what if we made the parser work with all `FixedWidthInteger` types? Then we could all the various integer types.
> 
> If you have the time you want to open a PR to do that? If not we can take care of it.
