### PR TITLE
Library evolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,16 @@ jobs:
       - uses: MaxDesiatov/swift-windows-action@v1
         with:
           swift-version: "5.5.1"
+  
+  library-evolution:
+    runs-on: macos-11
+    strategy:
+      matrix:
+        xcode:
+          - "13.2.1" # Swift 5.5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Build for library evolution
+        run: make build-for-library-evolution

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ test-swift:
 		--enable-test-discovery \
 		--parallel
 
+build-for-library-evolution:
+	swift build \
+		-c release \
+		--target Parsing \
+		-Xswiftc -emit-module-interface \
+		-Xswiftc -enable-library-evolution
+
+
 format:
 	swift format --in-place --recursive \
 		./Package.swift ./Sources ./Tests

--- a/Sources/Parsing/Builders/OneOfBuilder.swift
+++ b/Sources/Parsing/Builders/OneOfBuilder.swift
@@ -131,7 +131,13 @@ public enum OneOfBuilder {
   where P0.Input == P1.Input, P0.Output == P1.Output {
     public let p0: P0, p1: P1
 
-    @inlinable public init(_ p0: P0, _ p1: P1) {
+    @inlinable
+    public init(_ p0: P0, _ p1: P1) {
+      self.init(internal: p0, p1)
+    }
+    
+    @usableFromInline
+    init(internal p0: P0, _ p1: P1) {
       self.p0 = p0
       self.p1 = p1
     }

--- a/Sources/Parsing/Conversions/AnyConversion.swift
+++ b/Sources/Parsing/Conversions/AnyConversion.swift
@@ -117,8 +117,14 @@ public struct AnyConversion<Input, Output>: Conversion {
   /// - Parameter conversion: A conversion to wrap with a type eraser.
   @inlinable
   public init<C: Conversion>(_ conversion: C) where C.Input == Input, C.Output == Output {
+    self.init(internal: conversion)
+  }
+  
+  @usableFromInline
+  init<C: Conversion>(internal conversion: C) where C.Input == Input, C.Output == Output {
     self._apply = conversion.apply
     self._unapply = conversion.unapply
+
   }
 
   /// Creates a conversion that wraps the given closures in its ``apply(_:)`` and ``unapply(_:)``
@@ -136,13 +142,21 @@ public struct AnyConversion<Input, Output>: Conversion {
     apply: @escaping (Input) -> Output?,
     unapply: @escaping (Output) -> Input?
   ) {
+    self.init(_apply: apply, _unapply: unapply)
+  }
+  
+  @usableFromInline
+  init(
+    _apply: @escaping (Input) -> Output?,
+    _unapply: @escaping (Output) -> Input?
+  ) {
     self._apply = {
-      guard let value = apply($0)
+      guard let value = _apply($0)
       else { throw ConvertingError() }
       return value
     }
     self._unapply = {
-      guard let value = unapply($0)
+      guard let value = _unapply($0)
       else { throw ConvertingError() }
       return value
     }

--- a/Sources/Parsing/Conversions/Identity.swift
+++ b/Sources/Parsing/Conversions/Identity.swift
@@ -3,7 +3,12 @@ import Foundation
 extension Conversions {
   public struct Identity<Value>: Conversion {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     @inline(__always)

--- a/Sources/Parsing/Conversions/JSON.swift
+++ b/Sources/Parsing/Conversions/JSON.swift
@@ -65,6 +65,19 @@ extension Conversions {
       decoder: JSONDecoder = .init(),
       encoder: JSONEncoder = .init()
     ) {
+      self.init(
+        internal: type,
+        decoder: decoder,
+        encoder: encoder
+      )
+    }
+    
+    @usableFromInline
+    init(
+      internal type: Value.Type,
+      decoder: JSONDecoder = .init(),
+      encoder: JSONEncoder = .init()
+    ) {
       self.decoder = decoder
       self.encoder = encoder
     }

--- a/Sources/Parsing/Conversions/RawRepresentable.swift
+++ b/Sources/Parsing/Conversions/RawRepresentable.swift
@@ -79,7 +79,12 @@ extension Conversions {
   /// the ``Conversion/representing(_:)-swift.type.method`` operation, which constructs this type.
   public struct FromRawValue<Output: RawRepresentable>: Conversion {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     public func apply(_ input: Output.RawValue) throws -> Output {

--- a/Sources/Parsing/Conversions/String.swift
+++ b/Sources/Parsing/Conversions/String.swift
@@ -46,7 +46,12 @@ extension Conversions {
   /// the ``Conversion/string-swift.type.property-3u2b5`` operation, which constructs this type.
   public struct SubstringToString: Conversion {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     public func apply(_ input: Substring) -> String {
@@ -69,7 +74,12 @@ extension Conversions {
     Input.Element == UTF8.CodeUnit
   {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     public func apply(_ input: Input) -> String {

--- a/Sources/Parsing/Conversions/Substring.swift
+++ b/Sources/Parsing/Conversions/Substring.swift
@@ -55,7 +55,12 @@ extension Conversions {
   /// type under the hood.
   public struct UnicodeScalarViewToSubstring: Conversion {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     public func apply(_ input: Substring.UnicodeScalarView) -> Substring {
@@ -74,8 +79,13 @@ extension Conversions {
   /// the ``Conversion/substring-swift.type.property-4r1aj`` operation, which constructs this type.
   public struct UTF8ViewToSubstring: Conversion {
     @inlinable
-    public init() {}
-
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
+    
     @inlinable
     public func apply(_ input: Substring.UTF8View) -> Substring {
       Substring(input)

--- a/Sources/Parsing/Conversions/UTF8View.swift
+++ b/Sources/Parsing/Conversions/UTF8View.swift
@@ -22,7 +22,12 @@ extension Conversions {
   /// the ``Conversion/utf8-swift.type.property`` operation, which constructs this type.
   public struct SubstringToUTF8View: Conversion {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     public func apply(_ input: Substring) -> Substring.UTF8View {

--- a/Sources/Parsing/Internal/Deprecations.swift
+++ b/Sources/Parsing/Internal/Deprecations.swift
@@ -540,6 +540,11 @@ where InputToBytes.Input: PrependableCollection, InputToBytes.Output: Prependabl
 extension Newline {
   @inlinable
   public init<C>() where InputToBytes == Conversions.Identity<C> {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init<C>(internal: Void) where InputToBytes == Conversions.Identity<C> {
     self.inputToBytes = .init()
   }
 }
@@ -549,6 +554,11 @@ extension Newline where InputToBytes == Conversions.SubstringToUTF8View {
   @_disfavoredOverload
   @inlinable
   public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {
     self.inputToBytes = .init()
   }
 }
@@ -582,10 +592,24 @@ extension Prefix {
     maxLength: Int?,
     while predicate: @escaping (Input.Element) -> Bool
   ) {
+    self.init(
+      minLength: minLength,
+      maxLength: maxLength,
+      predicate: predicate
+    )
+  }
+  
+  @usableFromInline
+  init(
+    minLength: Int,
+    maxLength: Int?,
+    predicate: @escaping (Input.Element) -> Bool
+  ) {
     self.minimum = minLength
     self.maximum = maxLength
     self.predicate = predicate
   }
+  
 
   @available(
     *, deprecated,
@@ -595,6 +619,18 @@ extension Prefix {
   public init(
     minLength: Int,
     while predicate: @escaping (Input.Element) -> Bool
+  ) {
+    self.init(
+      minLength: minLength,
+      predicate: predicate
+    )
+  }
+  
+  @usableFromInline
+  init(
+    minLength: Int,
+    predicate: @escaping (Input.Element) -> Bool
+    
   ) {
     self.minimum = minLength
     self.maximum = nil
@@ -609,6 +645,14 @@ extension Prefix {
   public init(
     maxLength: Int,
     while predicate: @escaping (Input.Element) -> Bool
+  ) {
+    self.init(maxLength: maxLength, predicate: predicate)
+  }
+  
+  @usableFromInline
+  init(
+    maxLength: Int,
+    predicate: @escaping (Input.Element) -> Bool
   ) {
     self.minimum = 0
     self.maximum = maxLength
@@ -721,6 +765,11 @@ where SubstringParser.Input == Substring {
 extension FromSubstring where Input == ArraySlice<UInt8> {
   @inlinable
   public init(@ParserBuilder _ build: () -> SubstringParser) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> SubstringParser) {
     self.substringParser = build()
     self.toSubstring = { Substring(decoding: $0, as: UTF8.self) }
     self.fromSubstring = { ArraySlice($0.utf8) }
@@ -731,6 +780,11 @@ extension FromSubstring where Input == ArraySlice<UInt8> {
 extension FromSubstring where Input == Substring.UnicodeScalarView {
   @inlinable
   public init(@ParserBuilder _ build: () -> SubstringParser) {
+    self.init(build, internal: ())
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder _ build: () -> SubstringParser, internal: Void) {
     self.substringParser = build()
     self.toSubstring = Substring.init
     self.fromSubstring = \.unicodeScalars
@@ -741,6 +795,11 @@ extension FromSubstring where Input == Substring.UnicodeScalarView {
 extension FromSubstring where Input == Substring.UTF8View {
   @inlinable
   public init(@ParserBuilder _ build: () -> SubstringParser) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> SubstringParser) {
     self.substringParser = build()
     self.toSubstring = Substring.init
     self.fromSubstring = \.utf8
@@ -766,6 +825,11 @@ where UnicodeScalarsParser.Input == Substring.UnicodeScalarView {
 extension FromUnicodeScalarView where Input == ArraySlice<UInt8> {
   @inlinable
   public init(@ParserBuilder _ build: () -> UnicodeScalarsParser) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> UnicodeScalarsParser) {
     self.unicodeScalarsParser = build()
     self.toUnicodeScalars = { Substring(decoding: $0, as: UTF8.self).unicodeScalars }
     self.fromUnicodeScalars = { ArraySlice(Substring($0).utf8) }
@@ -776,6 +840,10 @@ extension FromUnicodeScalarView where Input == ArraySlice<UInt8> {
 extension FromUnicodeScalarView where Input == Substring {
   @inlinable
   public init(@ParserBuilder _ build: () -> UnicodeScalarsParser) {
+    self.init(internal: build)
+  }
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> UnicodeScalarsParser) {
     self.unicodeScalarsParser = build()
     self.toUnicodeScalars = \.unicodeScalars
     self.fromUnicodeScalars = Substring.init
@@ -786,6 +854,11 @@ extension FromUnicodeScalarView where Input == Substring {
 extension FromUnicodeScalarView where Input == Substring.UTF8View {
   @inlinable
   public init(@ParserBuilder _ build: () -> UnicodeScalarsParser) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> UnicodeScalarsParser) {
     self.unicodeScalarsParser = build()
     self.toUnicodeScalars = { Substring($0).unicodeScalars }
     self.fromUnicodeScalars = { Substring($0).utf8 }
@@ -811,6 +884,11 @@ where UTF8Parser.Input == Substring.UTF8View {
 extension FromUTF8View where Input == Substring {
   @inlinable
   public init(@ParserBuilder _ build: () -> UTF8Parser) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> UTF8Parser) {
     self.utf8Parser = build()
     self.toUTF8 = \.utf8
     self.fromUTF8 = Substring.init
@@ -821,6 +899,11 @@ extension FromUTF8View where Input == Substring {
 extension FromUTF8View where Input == Substring.UnicodeScalarView {
   @inlinable
   public init(@ParserBuilder _ build: () -> UTF8Parser) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> UTF8Parser) {
     self.utf8Parser = build()
     self.toUTF8 = { Substring($0).utf8 }
     self.fromUTF8 = { Substring($0).unicodeScalars }

--- a/Sources/Parsing/ParserPrinters/Always.swift
+++ b/Sources/Parsing/ParserPrinters/Always.swift
@@ -66,6 +66,11 @@ public struct Always<Input, Output>: ParserPrinter {
 
   @inlinable
   public init(_ output: Output) {
+    self.init(internal: output)
+  }
+  
+  @usableFromInline
+  init(internal output: Output) {
     self.output = output
   }
 
@@ -81,6 +86,11 @@ public struct Always<Input, Output>: ParserPrinter {
 extension Always where Input == Substring {
   @inlinable
   public init(_ output: Output) {
+    self.init(internal: output)
+  }
+  
+  @usableFromInline
+  init(internal output: Output) {
     self.output = output
   }
 }
@@ -88,6 +98,11 @@ extension Always where Input == Substring {
 extension Always where Input == Substring.UTF8View {
   @inlinable
   public init(_ output: Output) {
+    self.init(internal: output)
+  }
+  
+  @usableFromInline
+  init(internal output: Output) {
     self.output = output
   }
 }

--- a/Sources/Parsing/ParserPrinters/AnyParserPrinter.swift
+++ b/Sources/Parsing/ParserPrinters/AnyParserPrinter.swift
@@ -52,6 +52,14 @@ public struct AnyParserPrinter<Input, Output>: ParserPrinter {
     parse: @escaping (inout Input) throws -> Output,
     print: @escaping (Output, inout Input) throws -> Void
   ) {
+    self.init(internal: parse, print: print)
+  }
+  
+  @usableFromInline
+  init(
+    internal parse: @escaping (inout Input) throws -> Output,
+    print: @escaping (Output, inout Input) throws -> Void
+  ) {
     self.parser = parse
     self.printer = print
   }

--- a/Sources/Parsing/ParserPrinters/Bool.swift
+++ b/Sources/Parsing/ParserPrinters/Bool.swift
@@ -61,7 +61,12 @@ extension Parsers {
     Input.Element == UTF8.CodeUnit
   {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     public func parse(_ input: inout Input) throws -> Bool {

--- a/Sources/Parsing/ParserPrinters/Consumed.swift
+++ b/Sources/Parsing/ParserPrinters/Consumed.swift
@@ -8,6 +8,11 @@ where
 
   @inlinable
   public init(@ParserBuilder _ build: () -> Upstream) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(internal build: () -> Upstream) {
     self.upstream = build()
   }
 

--- a/Sources/Parsing/ParserPrinters/End.swift
+++ b/Sources/Parsing/ParserPrinters/End.swift
@@ -18,7 +18,12 @@
 /// > ``Parser/parse(_:)-6h1d0`` and ``Parser/parse(_:)-2wzcq`` methods.
 public struct End<Input: Sequence>: ParserPrinter {
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 
   @inlinable
   public func parse(_ input: inout Input) throws {
@@ -51,13 +56,23 @@ public struct End<Input: Sequence>: ParserPrinter {
 extension End where Input == Substring {
   @_disfavoredOverload
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 }
 
 extension End where Input == Substring.UTF8View {
   @_disfavoredOverload
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 }
 
 extension Parsers {

--- a/Sources/Parsing/ParserPrinters/Fail.swift
+++ b/Sources/Parsing/ParserPrinters/Fail.swift
@@ -34,6 +34,11 @@ public struct Fail<Input, Output>: ParserPrinter {
   /// - Parameter error: An error to throw when the parser is run.
   @inlinable
   public init(throwing error: Error) {
+    self.init(internal: error)
+  }
+  
+  @usableFromInline
+  init(internal error: Error) {
     self.error = error
   }
 

--- a/Sources/Parsing/ParserPrinters/Filter.swift
+++ b/Sources/Parsing/ParserPrinters/Filter.swift
@@ -38,6 +38,11 @@ extension Parsers {
 
     @inlinable
     public init(upstream: Upstream, predicate: @escaping (Upstream.Output) -> Bool) {
+      self.init(internal: upstream, predicate: predicate)
+    }
+    
+    @usableFromInline
+    init(internal upstream: Upstream, predicate: @escaping (Upstream.Output) -> Bool) {
       self.upstream = upstream
       self.predicate = predicate
     }

--- a/Sources/Parsing/ParserPrinters/First.swift
+++ b/Sources/Parsing/ParserPrinters/First.swift
@@ -23,7 +23,12 @@
 /// ```
 public struct First<Input: Collection>: Parser where Input.SubSequence == Input {
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 
   @inlinable
   public func parse(_ input: inout Input) throws -> Input.Element {
@@ -45,13 +50,23 @@ extension First: ParserPrinter where Input: PrependableCollection {
 extension First where Input == Substring {
   @_disfavoredOverload
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 }
 
 extension First where Input == Substring.UTF8View {
   @_disfavoredOverload
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 }
 
 extension Parsers {

--- a/Sources/Parsing/ParserPrinters/Float.swift
+++ b/Sources/Parsing/ParserPrinters/Float.swift
@@ -67,7 +67,12 @@ extension Parsers {
     Output: LosslessStringConvertible
   {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     public func parse(_ input: inout Input) throws -> Output {

--- a/Sources/Parsing/ParserPrinters/From.swift
+++ b/Sources/Parsing/ParserPrinters/From.swift
@@ -8,6 +8,11 @@ where Upstream.Output == Downstream.Input {
 
   @inlinable
   public init(_ conversion: Upstream, @ParserBuilder _ parser: () -> Downstream) {
+    self.init(internal: conversion, parser)
+  }
+  
+  @usableFromInline
+  init(internal conversion: Upstream, @ParserBuilder _ parser: () -> Downstream) {
     self.conversion = conversion
     self.parser = parser()
   }
@@ -49,6 +54,11 @@ extension Parsers {
 extension From {
   @inlinable
   public init(_ conversion: Upstream) where Downstream == Parsers.Identity<Upstream.Output> {
+    self.init(internal: conversion)
+  }
+  
+  @usableFromInline
+  init(internal conversion: Upstream) where Downstream == Parsers.Identity<Upstream.Output> {
     self.conversion = conversion
     self.parser = .init()
   }

--- a/Sources/Parsing/ParserPrinters/Int.swift
+++ b/Sources/Parsing/ParserPrinters/Int.swift
@@ -84,6 +84,11 @@ extension Parsers {
 
     @inlinable
     public init(radix: Int = 10) {
+      self.init(internal: radix)
+    }
+    
+    @usableFromInline
+    init(internal radix: Int = 10) {
       precondition((2...36).contains(radix), "Radix not in range 2...36")
       self.radix = radix
     }

--- a/Sources/Parsing/ParserPrinters/Lazy.swift
+++ b/Sources/Parsing/ParserPrinters/Lazy.swift
@@ -7,7 +7,12 @@ public final class Lazy<LazyParser: Parser>: Parser {
   public let createParser: () -> LazyParser
 
   @inlinable
-  public init(@ParserBuilder createParser: @escaping () -> LazyParser) {
+  public convenience init(@ParserBuilder createParser: @escaping () -> LazyParser) {
+    self.init(internal: createParser)
+  }
+  
+  @usableFromInline
+  init(internal createParser: @escaping () -> LazyParser) {
     self.createParser = createParser
   }
 

--- a/Sources/Parsing/ParserPrinters/Many.swift
+++ b/Sources/Parsing/ParserPrinters/Many.swift
@@ -238,6 +238,27 @@ extension Many where Printability == Void {
     @ParserBuilder separator: () -> Separator,
     @ParserBuilder terminator: () -> Terminator
   ) where I.Element == Element.Output {
+    self.init(
+      internal: length,
+      into: initialResult,
+      updateAccumulatingResult,
+      decumulator: decumulator,
+      element: element,
+      separator: separator,
+      terminator: terminator
+    )
+  }
+  
+  @usableFromInline
+  init<R: CountingRange, I: IteratorProtocol>(
+    internal length: R,
+    into initialResult: Result,
+    _ updateAccumulatingResult: @escaping (inout Result, Element.Output) throws -> Void,
+    decumulator: @escaping (Result) throws -> I,
+    @ParserBuilder element: () -> Element,
+    @ParserBuilder separator: () -> Separator,
+    @ParserBuilder terminator: () -> Terminator
+  ) where I.Element == Element.Output {
     self.element = element()
     self.initialResult = initialResult
     self.decumulator = { AnyIterator(try decumulator($0)) }
@@ -298,6 +319,25 @@ extension Many where Printability == Never {
   @inlinable
   public init<R: CountingRange>(
     _ length: R,
+    into initialResult: Result,
+    _ updateAccumulatingResult: @escaping (inout Result, Element.Output) throws -> Void,
+    @ParserBuilder element: () -> Element,
+    @ParserBuilder separator: () -> Separator,
+    @ParserBuilder terminator: () -> Terminator
+  ) {
+    self.init(
+      internal: length,
+      into: initialResult,
+      updateAccumulatingResult,
+      element: element,
+      separator: separator,
+      terminator: terminator
+    )
+  }
+  
+  @usableFromInline
+  init<R: CountingRange>(
+    internal length: R,
     into initialResult: Result,
     _ updateAccumulatingResult: @escaping (inout Result, Element.Output) throws -> Void,
     @ParserBuilder element: () -> Element,

--- a/Sources/Parsing/ParserPrinters/Map.swift
+++ b/Sources/Parsing/ParserPrinters/Map.swift
@@ -81,6 +81,11 @@ extension Parsers {
 
     @inlinable
     public init(upstream: Upstream, transform: @escaping (Upstream.Output) -> NewOutput) {
+      self.init(internal: upstream, transform: transform)
+    }
+    
+    @usableFromInline
+    init(internal upstream: Upstream, transform: @escaping (Upstream.Output) -> NewOutput) {
       self.upstream = upstream
       self.transform = transform
     }
@@ -102,6 +107,11 @@ extension Parsers {
 
     @inlinable
     public init(upstream: Upstream, output: Output) {
+      self.init(internal: upstream, output: output)
+    }
+    
+    @usableFromInline
+    init(internal upstream: Upstream, output: Output) {
       self.upstream = upstream
       self.output = output
     }
@@ -125,6 +135,11 @@ extension Parsers {
 
     @inlinable
     public init(upstream: Upstream, downstream: Downstream) {
+      self.init(internal: upstream, downstream: downstream)
+    }
+    
+    @usableFromInline
+    init(internal upstream: Upstream, downstream: Downstream) {
       self.upstream = upstream
       self.downstream = downstream
     }

--- a/Sources/Parsing/ParserPrinters/Not.swift
+++ b/Sources/Parsing/ParserPrinters/Not.swift
@@ -25,6 +25,11 @@ public struct Not<Upstream: Parser>: ParserPrinter {
   ///   fails.
   @inlinable
   public init(@ParserBuilder _ build: () -> Upstream) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(internal build: () -> Upstream) {
     self.upstream = build()
   }
 

--- a/Sources/Parsing/ParserPrinters/OneOf.swift
+++ b/Sources/Parsing/ParserPrinters/OneOf.swift
@@ -156,6 +156,11 @@ public struct OneOf<Parsers: Parser>: Parser {
 
   @inlinable
   public init(@OneOfBuilder _ build: () -> Parsers) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(internal build: () -> Parsers) {
     self.parsers = build()
   }
 

--- a/Sources/Parsing/ParserPrinters/OneOfMany.swift
+++ b/Sources/Parsing/ParserPrinters/OneOfMany.swift
@@ -22,6 +22,11 @@ extension Parsers {
 
     @inlinable
     public init(_ parsers: [Parsers]) {
+      self.init(internal: parsers)
+    }
+    
+    @usableFromInline
+    init(internal parsers: [Parsers]) {
       self.parsers = parsers
     }
 

--- a/Sources/Parsing/ParserPrinters/Optionally.swift
+++ b/Sources/Parsing/ParserPrinters/Optionally.swift
@@ -37,6 +37,11 @@ public struct Optionally<Wrapped: Parser>: Parser {
 
   @inlinable
   public init(@ParserBuilder _ build: () -> Wrapped) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> Wrapped) {
     self.wrapped = build()
   }
 

--- a/Sources/Parsing/ParserPrinters/Parse.swift
+++ b/Sources/Parsing/ParserPrinters/Parse.swift
@@ -44,6 +44,11 @@ public struct Parse<Parsers: Parser>: Parser {
   /// - Parameter with: A parser builder that will accumulate non-void outputs in a tuple.
   @inlinable
   public init(@ParserBuilder with build: () -> Parsers) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(internal build: () -> Parsers) {
     self.parsers = build()
   }
 
@@ -80,6 +85,14 @@ public struct Parse<Parsers: Parser>: Parser {
     _ transform: @escaping (Upstream.Output) -> NewOutput,
     @ParserBuilder with build: () -> Upstream
   ) where Parsers == Parsing.Parsers.Map<Upstream, NewOutput> {
+    self.init(internal: transform, with: build)
+  }
+  
+  @usableFromInline
+  init<Upstream, NewOutput>(
+    internal transform: @escaping (Upstream.Output) -> NewOutput,
+    @ParserBuilder with build: () -> Upstream
+  ) where Parsers == Parsing.Parsers.Map<Upstream, NewOutput> {
     self.parsers = build().map(transform)
   }
 
@@ -101,6 +114,14 @@ public struct Parse<Parsers: Parser>: Parser {
   @inlinable
   public init<Upstream, NewOutput>(
     _ output: NewOutput,
+    @ParserBuilder with build: () -> Upstream
+  ) where Parsers == Parsing.Parsers.MapConstant<Upstream, NewOutput> {
+    self.init(internal: output, with: build)
+  }
+  
+  @usableFromInline
+  init<Upstream, NewOutput>(
+    internal output: NewOutput,
     @ParserBuilder with build: () -> Upstream
   ) where Parsers == Parsing.Parsers.MapConstant<Upstream, NewOutput> {
     self.parsers = build().map { output }
@@ -137,6 +158,14 @@ public struct Parse<Parsers: Parser>: Parser {
   @inlinable
   public init<Upstream, Downstream>(
     _ conversion: Downstream,
+    @ParserBuilder with build: () -> Upstream
+  ) where Parsers == Parsing.Parsers.MapConversion<Upstream, Downstream> {
+    self.init(internal: conversion, with: build)
+  }
+  
+  @usableFromInline
+  init<Upstream, Downstream>(
+    internal conversion: Downstream,
     @ParserBuilder with build: () -> Upstream
   ) where Parsers == Parsing.Parsers.MapConversion<Upstream, Downstream> {
     self.parsers = build().map(conversion)
@@ -193,6 +222,11 @@ public struct ParsePrint<ParserPrinters: ParserPrinter>: ParserPrinter {
 
   @inlinable
   public init(@ParserBuilder with build: () -> ParserPrinters) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(internal build: () -> ParserPrinters) {
     self.parserPrinters = build()
   }
 
@@ -201,12 +235,28 @@ public struct ParsePrint<ParserPrinters: ParserPrinter>: ParserPrinter {
     _ output: NewOutput,
     @ParserBuilder with build: () -> Upstream
   ) where ParserPrinters == Parsers.MapConstant<Upstream, NewOutput> {
+    self.init(internal: output, with: build)
+  }
+  
+  @usableFromInline
+  init<Upstream, NewOutput>(
+    internal output: NewOutput,
+    @ParserBuilder with build: () -> Upstream
+  ) where ParserPrinters == Parsers.MapConstant<Upstream, NewOutput> {
     self.parserPrinters = build().map { output }
   }
 
   @inlinable
   public init<Upstream, Downstream>(
     _ conversion: Downstream,
+    @ParserBuilder with build: () -> Upstream
+  ) where ParserPrinters == Parsers.MapConversion<Upstream, Downstream> {
+    self.init(internal: conversion, with: build)
+  }
+  
+  @usableFromInline
+  init<Upstream, Downstream>(
+    internal conversion: Downstream,
     @ParserBuilder with build: () -> Upstream
   ) where ParserPrinters == Parsers.MapConversion<Upstream, Downstream> {
     self.parserPrinters = build().map(conversion)

--- a/Sources/Parsing/ParserPrinters/ParseableFormatStyle.swift
+++ b/Sources/Parsing/ParserPrinters/ParseableFormatStyle.swift
@@ -12,6 +12,11 @@
 
     @inlinable
     public init(_ style: Style) {
+      self.init(internal: style)
+    }
+    
+    @usableFromInline
+    init(internal style: Style) {
       self.style = style
     }
 

--- a/Sources/Parsing/ParserPrinters/Peek.swift
+++ b/Sources/Parsing/ParserPrinters/Peek.swift
@@ -31,6 +31,11 @@ public struct Peek<Upstream: Parser>: ParserPrinter {
   /// - Parameter build: A parser this parser wants to inspect.
   @inlinable
   public init(@ParserBuilder _ build: () -> Upstream) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(@ParserBuilder internal build: () -> Upstream) {
     self.upstream = build()
   }
 

--- a/Sources/Parsing/ParserPrinters/Pipe.swift
+++ b/Sources/Parsing/ParserPrinters/Pipe.swift
@@ -61,6 +61,11 @@ extension Parsers {
 
     @inlinable
     public init(upstream: Upstream, downstream: Downstream) {
+      self.init(internal: upstream, downstream: downstream)
+    }
+    
+    @usableFromInline
+    init(internal upstream: Upstream, downstream: Downstream) {
       self.upstream = upstream
       self.downstream = downstream
     }

--- a/Sources/Parsing/ParserPrinters/Prefix.swift
+++ b/Sources/Parsing/ParserPrinters/Prefix.swift
@@ -74,6 +74,11 @@ public struct Prefix<Input: Collection>: Parser where Input.SubSequence == Input
   ///     Once the predicate returns `false` it will not be called again.
   @inlinable
   public init<R: CountingRange>(_ length: R, while predicate: ((Input.Element) -> Bool)? = nil) {
+    self.init(internal: length, while: predicate)
+  }
+  
+  @usableFromInline
+  init<R: CountingRange>(internal length: R, while predicate: ((Input.Element) -> Bool)? = nil) {
     self.minimum = length.minimum
     self.maximum = length.maximum
     self.predicate = predicate
@@ -93,6 +98,11 @@ public struct Prefix<Input: Collection>: Parser where Input.SubSequence == Input
   ///     the predicate returns `false` it will not be called again.
   @inlinable
   public init(while predicate: @escaping (Input.Element) -> Bool) {
+    self.init(internal: predicate)
+  }
+  
+  @usableFromInline
+  init(internal predicate: @escaping (Input.Element) -> Bool) {
     self.minimum = 0
     self.maximum = nil
     self.predicate = predicate

--- a/Sources/Parsing/ParserPrinters/PrefixThrough.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixThrough.swift
@@ -20,6 +20,14 @@ public struct PrefixThrough<Input: Collection>: Parser where Input.SubSequence =
     _ possibleMatch: Input,
     by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
   ) {
+    self.init(internal: possibleMatch, by: areEquivalent)
+  }
+  
+  @usableFromInline
+  init(
+    internal possibleMatch: Input,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+  ) {
     self.possibleMatch = possibleMatch
     self.areEquivalent = areEquivalent
   }

--- a/Sources/Parsing/ParserPrinters/PrefixUpTo.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixUpTo.swift
@@ -20,6 +20,14 @@ public struct PrefixUpTo<Input: Collection>: Parser where Input.SubSequence == I
     _ possibleMatch: Input,
     by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
   ) {
+    self.init(internal: possibleMatch, by: areEquivalent)
+  }
+  
+  @usableFromInline
+  init(
+    internal possibleMatch: Input,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+  ) {
     self.possibleMatch = possibleMatch
     self.areEquivalent = areEquivalent
   }

--- a/Sources/Parsing/ParserPrinters/Printing.swift
+++ b/Sources/Parsing/ParserPrinters/Printing.swift
@@ -57,6 +57,14 @@ extension Parsers {
       parser: Parser,
       printer: Printer
     ) {
+      self.init(internal: parser, printer: printer)
+    }
+    
+    @usableFromInline
+    init(
+      internal parser: Parser,
+      printer: Printer
+    ) {
       self.parser = parser
       self.printer = printer
     }
@@ -81,6 +89,14 @@ extension Parsers {
       parser: Upstream,
       printer: @escaping (Upstream.Output, inout Upstream.Input) -> Void
     ) {
+      self.init(internal: parser, printer: printer)
+    }
+    
+    @usableFromInline
+    init(
+      internal parser: Upstream,
+      printer: @escaping (Upstream.Output, inout Upstream.Input) -> Void
+    ) {
       self.parser = parser
       self.printer = printer
     }
@@ -103,6 +119,14 @@ extension Parsers {
     @inlinable
     public init(
       parser: Upstream,
+      printer: @escaping (Upstream.Output, inout Upstream.Input) throws -> Void
+    ) {
+      self.init(internal: parser, printer: printer)
+    }
+    
+    @usableFromInline
+    init(
+      internal parser: Upstream,
       printer: @escaping (Upstream.Output, inout Upstream.Input) throws -> Void
     ) {
       self.parser = parser

--- a/Sources/Parsing/ParserPrinters/Pullback.swift
+++ b/Sources/Parsing/ParserPrinters/Pullback.swift
@@ -39,6 +39,11 @@ extension Parsers {
 
     @inlinable
     public init(downstream: Downstream, keyPath: WritableKeyPath<Input, Downstream.Input>) {
+      self.init(internal: downstream, keyPath: keyPath)
+    }
+    
+    @usableFromInline
+    init(internal downstream: Downstream, keyPath: WritableKeyPath<Input, Downstream.Input>) {
       self.downstream = downstream
       self.keyPath = keyPath
     }

--- a/Sources/Parsing/ParserPrinters/Rest.swift
+++ b/Sources/Parsing/ParserPrinters/Rest.swift
@@ -23,7 +23,12 @@
 /// to coalesce the error into a default output value.
 public struct Rest<Input: Collection>: Parser where Input.SubSequence == Input {
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 
   @inlinable
   public func parse(_ input: inout Input) throws -> Input {
@@ -74,13 +79,23 @@ extension Rest: ParserPrinter where Input: PrependableCollection {
 extension Rest where Input == Substring {
   @_disfavoredOverload
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 }
 
 extension Rest where Input == Substring.UTF8View {
   @_disfavoredOverload
   @inlinable
-  public init() {}
+  public init() {
+    self.init(internal: ())
+  }
+  
+  @usableFromInline
+  init(internal: Void) {}
 }
 
 extension Parsers {

--- a/Sources/Parsing/ParserPrinters/Skip.swift
+++ b/Sources/Parsing/ParserPrinters/Skip.swift
@@ -5,6 +5,11 @@ public struct Skip<Parsers: Parser>: Parser {
 
   @inlinable
   public init(@ParserBuilder _ build: () -> Parsers) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(internal build: () -> Parsers) {
     self.parsers = build()
   }
 

--- a/Sources/Parsing/ParserPrinters/StartsWith.swift
+++ b/Sources/Parsing/ParserPrinters/StartsWith.swift
@@ -55,6 +55,15 @@ public struct StartsWith<Input: Collection>: Parser where Input.SubSequence == I
     by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
   )
   where PossiblePrefix.Element == Input.Element {
+    self.init(internal: possiblePrefix, by: areEquivalent)
+  }
+  
+  @usableFromInline
+  init<PossiblePrefix: Collection>(
+    internal possiblePrefix: PossiblePrefix,
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+  )
+  where PossiblePrefix.Element == Input.Element {
     self.count = possiblePrefix.count
     self.possiblePrefix = AnyCollection(possiblePrefix)
     self.startsWith = { input in input.starts(with: possiblePrefix, by: areEquivalent) }

--- a/Sources/Parsing/ParserPrinters/UUID.swift
+++ b/Sources/Parsing/ParserPrinters/UUID.swift
@@ -64,7 +64,12 @@ extension Parsers {
     Input.Element == UTF8.CodeUnit
   {
     @inlinable
-    public init() {}
+    public init() {
+      self.init(internal: ())
+    }
+    
+    @usableFromInline
+    init(internal: Void) {}
 
     @inlinable
     public func parse(_ input: inout Input) throws -> UUID {

--- a/Sources/Parsing/ParserPrinters/Whitespace.swift
+++ b/Sources/Parsing/ParserPrinters/Whitespace.swift
@@ -179,6 +179,12 @@ extension Whitespace {
   @inlinable
   public init<C>(_ length: Length, _ configuration: Configuration = .all)
   where InputToBytes == Conversions.Identity<C> {
+    self.init(internal: length, configuration)
+  }
+  
+  @usableFromInline
+  init<C>(internal length: Length, _ configuration: Configuration)
+  where InputToBytes == Conversions.Identity<C> {
     self.length = length
     self.configuration = configuration
     self.inputToBytes = .init()
@@ -195,6 +201,11 @@ extension Whitespace where InputToBytes == Conversions.SubstringToUTF8View {
   @_disfavoredOverload
   @inlinable
   public init(_ length: Length, _ configuration: Configuration = .all) {
+    self.init(internal: length, configuration)
+  }
+  
+  @usableFromInline
+  init(internal length: Length, _ configuration: Configuration) {
     self.length = length
     self.configuration = configuration
     self.inputToBytes = .init()

--- a/Sources/Parsing/Parsers/AnyParser.swift
+++ b/Sources/Parsing/Parsers/AnyParser.swift
@@ -44,6 +44,11 @@ public struct AnyParser<Input, Output>: Parser {
   ///   executed each time the ``parse(_:)`` method is called on the resulting parser.
   @inlinable
   public init(_ parse: @escaping (inout Input) throws -> Output) {
+    self.init(internal: parse)
+  }
+  
+  @usableFromInline
+  init(internal parse: @escaping (inout Input) throws -> Output) {
     self.parser = parse
   }
 

--- a/Sources/Parsing/Parsers/CompactMap.swift
+++ b/Sources/Parsing/Parsers/CompactMap.swift
@@ -63,6 +63,14 @@ extension Parsers {
       upstream: Upstream,
       transform: @escaping (Upstream.Output) -> Output?
     ) {
+      self.init(internal: upstream, transform: transform)
+    }
+    
+    @usableFromInline
+    init(
+      internal upstream: Upstream,
+      transform: @escaping (Upstream.Output) -> Output?
+    ) {
       self.upstream = upstream
       self.transform = transform
     }

--- a/Sources/Parsing/Parsers/FlatMap.swift
+++ b/Sources/Parsing/Parsers/FlatMap.swift
@@ -35,6 +35,11 @@ extension Parsers {
 
     @inlinable
     public init(upstream: Upstream, transform: @escaping (Upstream.Output) -> NewParser) {
+      self.init(internal: upstream, transform: transform)
+    }
+    
+    @usableFromInline
+    init(internal upstream: Upstream, transform: @escaping (Upstream.Output) -> NewParser) {
       self.upstream = upstream
       self.transform = transform
     }

--- a/Sources/Parsing/Parsers/Stream.swift
+++ b/Sources/Parsing/Parsers/Stream.swift
@@ -35,6 +35,11 @@ public struct Stream<Parsers: Parser>: Parser where Parsers.Input: RangeReplacea
 
   @inlinable
   public init(@ParserBuilder build: () -> Parsers) {
+    self.init(internal: build)
+  }
+  
+  @usableFromInline
+  init(internal build: () -> Parsers) {
     self.parsers = build()
   }
 


### PR DESCRIPTION
When building with flag, 
`@inlinable init` do not compile with the error:
<img width="748" alt="Screenshot 2023-02-11 at 17 14 59" src="https://user-images.githubusercontent.com/12966579/218271661-7b25cc6f-2df8-4465-b893-212fe822839a.png">

However marking `@usableFromInline` a `public init` is not allowed. 

<img width="683" alt="Screenshot 2023-02-11 at 17 15 31" src="https://user-images.githubusercontent.com/12966579/218271680-40b3a197-30bf-4be8-82b4-b8889baa62e0.png">

This PR creates an internal `init` as suggested by the first error that gets called from the `public init`
 
Refs: 
 - https://github.com/pointfreeco/swift-parsing/discussions/284
 - https://github.com/pointfreeco/swift-composable-architecture/pull/1443

