### PR TITLE
Add Backtrack parser.

### DIFF
--- a/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
@@ -70,7 +70,7 @@ It backtracks the input to its original value when the parser fails so that late
 The only time you need to worry about explicitly backtracking input is when making your own
 ``Parser`` conformances. As a general rule of thumb, if your parser recovers from all failures
 in the `parse` method then it should backtrack the input to its state before the error was thrown.
-This is exactly how ``OneOf``, ``Backtrack``, ``Optionally``, ``Not`` and ``Parser/replaceError(with:)`` 
+This is exactly how ``OneOf``, ``Backtracking``, ``Optionally``, ``Not`` and ``Parser/replaceError(with:)`` 
 work.
 
 ## Performance

--- a/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
@@ -70,7 +70,7 @@ It backtracks the input to its original value when the parser fails so that late
 The only time you need to worry about explicitly backtracking input is when making your own
 ``Parser`` conformances. As a general rule of thumb, if your parser recovers from all failures
 in the `parse` method then it should backtrack the input to its state before the error was thrown.
-This is exactly how ``OneOf``, ``Backtrack``, ``Optionally`` and ``Parser/replaceError(with:)`` 
+This is exactly how ``OneOf``, ``Backtrack``, ``Optionally``, ``Not`` and ``Parser/replaceError(with:)`` 
 work.
 
 ## Performance

--- a/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
+++ b/Sources/Parsing/Documentation.docc/Articles/Backtracking.md
@@ -70,7 +70,8 @@ It backtracks the input to its original value when the parser fails so that late
 The only time you need to worry about explicitly backtracking input is when making your own
 ``Parser`` conformances. As a general rule of thumb, if your parser recovers from all failures
 in the `parse` method then it should backtrack the input to its state before the error was thrown.
-This is exactly how ``OneOf``, ``Optionally`` and ``Parser/replaceError(with:)`` work.
+This is exactly how ``OneOf``, ``Backtrack``, ``Optionally`` and ``Parser/replaceError(with:)`` 
+work.
 
 ## Performance
 

--- a/Sources/Parsing/ParserPrinters/Backtrack.swift
+++ b/Sources/Parsing/ParserPrinters/Backtrack.swift
@@ -1,0 +1,31 @@
+/// A parser that attempts to run another parser and if it fails the input will be restored to its
+/// original value.
+///
+/// Use this parser if you want to manually manage the backtracking behavior of your parsers.
+/// Another tool for managing backtracking is the ``OneOf`` parser. Also see the
+/// <doc:Backtracking> article for more information on backtracking.
+public struct Backtrack<Upstream: Parser>: Parser {
+  public let upstream: Upstream
+
+  public init(
+    @ParserBuilder upstream: () -> Upstream
+  ) {
+    self.upstream = upstream()
+  }
+
+  public func parse(_ input: inout Upstream.Input) throws -> Upstream.Output {
+    let original = input
+    do {
+      return try self.upstream.parse(&input)
+    } catch {
+      input = original
+      throw error
+    }
+  }
+}
+
+extension Backtrack: ParserPrinter where Upstream: ParserPrinter {
+  public func print(_ output: Upstream.Output, into input: inout Upstream.Input) throws {
+    try self.upstream.print(output, into: &input)
+  }
+}

--- a/Sources/Parsing/ParserPrinters/Backtracking.swift
+++ b/Sources/Parsing/ParserPrinters/Backtracking.swift
@@ -4,7 +4,7 @@
 /// Use this parser if you want to manually manage the backtracking behavior of your parsers.
 /// Another tool for managing backtracking is the ``OneOf`` parser. Also see the
 /// <doc:Backtracking> article for more information on backtracking.
-public struct Backtrack<Upstream: Parser>: Parser {
+public struct Backtracking<Upstream: Parser>: Parser {
   public let upstream: Upstream
 
   public init(
@@ -24,7 +24,7 @@ public struct Backtrack<Upstream: Parser>: Parser {
   }
 }
 
-extension Backtrack: ParserPrinter where Upstream: ParserPrinter {
+extension Backtracking: ParserPrinter where Upstream: ParserPrinter {
   public func print(_ output: Upstream.Output, into input: inout Upstream.Input) throws {
     try self.upstream.print(output, into: &input)
   }

--- a/Sources/Parsing/ParserPrinters/OneOf.swift
+++ b/Sources/Parsing/ParserPrinters/OneOf.swift
@@ -150,12 +150,12 @@
 ///
 /// The ``OneOf`` parser is the primary tool for introducing backtracking into your parsers,
 /// which means to undo the consumption of a parser when it fails. For more information, see the
-/// article <doc:Backtracking> and the ``Backtrack`` parser.
+/// article <doc:Backtracking> and the ``Backtracking`` parser.
 ///
 /// > Note: While ``OneOf`` does undo any input consumption before running each parser listed
 /// in the builder closure, it does _not_ undo the consumption of the last parser. If you want to
 /// enforce backtracking for the entire ``OneOf`` parser you need to further wrap it inside the
-/// ``Backtrack`` parser.
+/// ``Backtracking`` parser.
 public struct OneOf<Parsers: Parser>: Parser {
   public let parsers: Parsers
 

--- a/Sources/Parsing/ParserPrinters/OneOf.swift
+++ b/Sources/Parsing/ParserPrinters/OneOf.swift
@@ -150,7 +150,12 @@
 ///
 /// The ``OneOf`` parser is the primary tool for introducing backtracking into your parsers,
 /// which means to undo the consumption of a parser when it fails. For more information, see the
-/// article <doc:Backtracking>.
+/// article <doc:Backtracking> and the ``Backtrack`` parser.
+///
+/// > Note: While ``OneOf`` does undo any input consumption before running each parser listed
+/// in the builder closure, it does _not_ undo the consumption of the last parser. If you want to
+/// enforce backtracking for the entire ``OneOf`` parser you need to further wrap it inside the
+/// ``Backtrack`` parser.
 public struct OneOf<Parsers: Parser>: Parser {
   public let parsers: Parsers
 

--- a/Tests/ParsingTests/BacktrackTests.swift
+++ b/Tests/ParsingTests/BacktrackTests.swift
@@ -1,0 +1,26 @@
+import Parsing
+import XCTest
+
+final class BacktrackTests: XCTestCase {
+  func testFailure() {
+    var input = "AB"[...]
+    XCTAssertThrowsError(
+      try Backtrack { Prefix(2) { $0 == "A" } }
+        .parse(&input)
+    )
+    XCTAssertEqual("AB", Substring(input))
+  }
+
+  func testSuccess() throws {
+    var input = "AB"[...]
+    let output = try Backtrack { Prefix(1) { $0 == "A" } }
+      .parse(&input)
+    XCTAssertEqual("B", Substring(input))
+    XCTAssertEqual("A", output)
+  }
+
+  func testPrint() throws {
+    let input = try Backtrack { Prefix(2) { $0 == "A" } }.print("AA")
+    XCTAssertEqual(input, "AA")
+  }
+}

--- a/Tests/ParsingTests/BacktrackTests.swift
+++ b/Tests/ParsingTests/BacktrackTests.swift
@@ -5,7 +5,7 @@ final class BacktrackTests: XCTestCase {
   func testFailure() {
     var input = "AB"[...]
     XCTAssertThrowsError(
-      try Backtrack { Prefix(2) { $0 == "A" } }
+      try Backtracking { Prefix(2) { $0 == "A" } }
         .parse(&input)
     )
     XCTAssertEqual("AB", Substring(input))
@@ -13,14 +13,14 @@ final class BacktrackTests: XCTestCase {
 
   func testSuccess() throws {
     var input = "AB"[...]
-    let output = try Backtrack { Prefix(1) { $0 == "A" } }
+    let output = try Backtracking { Prefix(1) { $0 == "A" } }
       .parse(&input)
     XCTAssertEqual("B", Substring(input))
     XCTAssertEqual("A", output)
   }
 
   func testPrint() throws {
-    let input = try Backtrack { Prefix(2) { $0 == "A" } }.print("AA")
+    let input = try Backtracking { Prefix(2) { $0 == "A" } }.print("AA")
     XCTAssertEqual(input, "AA")
   }
 }

--- a/Tests/ParsingTests/OneOfTests.swift
+++ b/Tests/ParsingTests/OneOfTests.swift
@@ -2,6 +2,15 @@ import Parsing
 import XCTest
 
 final class OneOfTests: XCTestCase {
+  func testOneOfSingleton() {
+    var input = "AB"[...]
+    XCTAssertThrowsError(
+      try OneOf { Prefix(2) { $0 == "A" } }
+        .parse(&input)
+    )
+    XCTAssertEqual("B", Substring(input))
+  }
+
   func testOneOfFirstSuccess() {
     var input = "New York, Hello!"[...]
     XCTAssertNoThrow(


### PR DESCRIPTION
Due to the discussions in #286 we realized that there is no way to explicitly backtrack just a single parser since `OneOf` does not undo the consumption of the last parser run. We think we want to keep that behavior, but think also explicit backtracking can be good, so we are adding a dedicated `Backtrack` parser.