### PR TITLE
Downstream ParseBuilder should use Downstream.Input as Input

### DIFF
--- a/Sources/Parsing/ParserPrinters/Pipe.swift
+++ b/Sources/Parsing/ParserPrinters/Pipe.swift
@@ -31,7 +31,7 @@ extension Parser {
   /// - Parameter downstream: A parser that parses the output of this parser.
   /// - Returns: A parser that pipes this parser's output into another parser.  @inlinable
   public func pipe<Downstream>(
-    @ParserBuilder<Downstream.Input> _ build: () -> Downstream
+    @ParserBuilder<Output> _ build: () -> Downstream
   ) -> Parsers.Pipe<Self, Downstream> {
     .init(upstream: self, downstream: build())
   }
@@ -39,7 +39,7 @@ extension Parser {
 
 extension Parser where Input: Collection {
   public func pipe<Downstream>(
-    @ParserBuilder<Downstream.Input> _ build: () -> Downstream
+    @ParserBuilder<Output> _ build: () -> Downstream
   ) -> Parsers.Pipe<Self, ParserBuilder<Input>.SkipSecond<Downstream, Parsers.PipeEnd<Self.Input>>>
   {
     .init(

--- a/Sources/Parsing/ParserPrinters/Pipe.swift
+++ b/Sources/Parsing/ParserPrinters/Pipe.swift
@@ -31,7 +31,7 @@ extension Parser {
   /// - Parameter downstream: A parser that parses the output of this parser.
   /// - Returns: A parser that pipes this parser's output into another parser.  @inlinable
   public func pipe<Downstream>(
-    @ParserBuilder<Input> _ build: () -> Downstream
+    @ParserBuilder<Downstream.Input> _ build: () -> Downstream
   ) -> Parsers.Pipe<Self, Downstream> {
     .init(upstream: self, downstream: build())
   }
@@ -39,7 +39,7 @@ extension Parser {
 
 extension Parser where Input: Collection {
   public func pipe<Downstream>(
-    @ParserBuilder<Input> _ build: () -> Downstream
+    @ParserBuilder<Downstream.Input> _ build: () -> Downstream
   ) -> Parsers.Pipe<Self, ParserBuilder<Input>.SkipSecond<Downstream, Parsers.PipeEnd<Self.Input>>>
   {
     .init(

--- a/Tests/ParsingTests/PipeTests.swift
+++ b/Tests/ParsingTests/PipeTests.swift
@@ -49,4 +49,18 @@ final class PipeTests: XCTestCase {
     }
     XCTAssertEqual("true", Substring(input))
   }
+
+  func testUsingDownstreamInput() {
+    let utf8InputParser = Parse(input: Substring.UTF8View.self) {
+      Always("Hello world"[...])
+    }
+    let pipedParser = utf8InputParser.pipe {
+      Parse(input: Substring.self) {
+        Always("123")
+      }
+    }
+    var input = ""[...].utf8
+    let output = pipedParser.parse(&input)
+    XCTAssertEqual("123", output)
+  }
 }


### PR DESCRIPTION
I'm currently trying to migrate some parsing code to the 5.8 branch. I think I found a bug, but it could also be a misunderstanding with the latest changes.

The ParseBuilder is for Downstream so it should use it’s input. Or Upstream.Output as pipe runs the downstream parser on the output of the upstream parser. Which is why Upstream.Output == Downstream.Input.

With the 5.8 changes pipe uses the wrong input here. This only causes issues, if Upstream and Downstream have a different Input type.

The test can probably be simplified.