### PR TITLE
Fix seconds mapping in Date benchmark

### DIFF
--- a/Sources/swift-parsing-benchmark/Date.swift
+++ b/Sources/swift-parsing-benchmark/Date.swift
@@ -47,9 +47,9 @@ let dateSuite = BenchmarkSuite(name: "Date") { suite in
                 "+".utf8.map { 1 }
                 "-".utf8.map { -1 }
               }
-              Digits(2).map { $0 * 60 }
+              Digits(2).map { $0 * 60 * 60 }
               ":".utf8
-              Digits(2)
+              Digits(2).map { $0 * 60 }
             }
             .map { $0 * ($1 + $2) }
           }


### PR DESCRIPTION
The offset in the timezone was mapping to minutes rather than seconds
```diff
let input = "1979-05-27T00:32:00+12:00"
let expected: DateComponents = .init(
-     timeZone: TimeZone(identifier: "GMT+0012"),
+     timeZone: TimeZone(identifier: "GMT+1200"),
      year: 1979,
      month: 5,
      day: 27,
      hour: 0,
      minute: 32,
      second: 0
)
```