### PR TITLE
Fix `Formatted` parser

### DIFF
--- a/Sources/Parsing/ParserPrinters/ParseableFormatStyle.swift
+++ b/Sources/Parsing/ParserPrinters/ParseableFormatStyle.swift
@@ -24,7 +24,7 @@
           at: input
         )
       }
-      input.removeFirst(input.distance(from: input.startIndex, to: input.endIndex))
+      input.removeFirst(input.distance(from: match.range.lowerBound, to: match.range.upperBound))
       return match.output
     }
 

--- a/Tests/ParsingTests/ParseableFormatTests.swift
+++ b/Tests/ParsingTests/ParseableFormatTests.swift
@@ -19,5 +19,11 @@
         "TOTAL: $42.42"
       )
     }
+
+    func testFormatted_PartiallyConsumes() throws {
+      var input = "12.34°N"[...]
+      XCTAssertEqual(12.34, try Formatted(.number).parse(&input))
+      XCTAssertEqual(String(input), "°N")
+    }
   }
 #endif


### PR DESCRIPTION
It should only consume the match range.