### PR TITLE
Case key path support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - test
           # - benchmarks
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: System
@@ -29,15 +29,15 @@ jobs:
         run: make ${{ matrix.command }}
 
   ubuntu_tests:
+    name: Ubuntu (Swift ${{ matrix.swift }})
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-20.04]
-
-    runs-on: ${{ matrix.os }}
-
+        swift:
+          - '5.9'
     steps:
-      - uses: actions/checkout@v3
-      - name: Build
-        run: swift build
-      - name: Run tests
-        run: swift test
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: ${{ matrix.swift }}
+      - uses: actions/checkout@v4
+      - run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "5da6989aae464f324eef5c5b52bdb7974725ab81",
-        "version" : "1.0.0"
+        "branch" : "case-key-paths",
+        "revision" : "7112451690777c2145aa86310d7f205c40e40998"
       }
     },
     {
@@ -34,6 +34,15 @@
       "state" : {
         "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.0.0"),
     .package(url: "https://github.com/google/swift-benchmark", from: "0.1.1"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "case-key-paths"),
   ],
   targets: [
     .target(

--- a/Sources/Parsing/Conversions/Enum.swift
+++ b/Sources/Parsing/Conversions/Enum.swift
@@ -7,17 +7,23 @@ extension Conversion {
   /// Useful for transforming the output of a ``ParserPrinter`` into an enum:
   ///
   /// ```swift
+  /// @CasePathable
   /// enum Expression {
   ///   case add(Int, Int)
   ///   ...
   /// }
   ///
-  /// let add = ParsePrint(.case(Expression.add)) {
-  ///   Int.parser()
-  ///   "+"
-  ///   Int.parser()
+  /// struct Add: ParserPrinter{
+  ///   var body: some ParserPrinter<Substring, Expression> {
+  ///     ParsePrint(.case(\Expression.Cases.add)) {
+  ///       Int.parser()
+  ///       "+"
+  ///       Int.parser()
+  ///     }
+  ///   }
   /// }
-  /// try add.parse("1+2")  // Expression.add(1, 2)
+  ///
+  /// try Add().parse("1+2")  // Expression.add(1, 2)
   /// ```
   ///
   /// To transform the output of a ``ParserPrinter`` into a struct, see ``memberwise(_:)``.
@@ -28,21 +34,28 @@ extension Conversion {
   /// - Returns: A conversion that can embed the associated values of an enum case into the case,
   ///   and extract the associated values from the case.
   @inlinable
+  public static func `case`<Values, Enum: CasePathable>(
+    _ keyPath: CaseKeyPath<Enum, Values>
+  ) -> Self where Self == AnyCasePath<Enum, Values> {
+    AnyCasePath(keyPath)
+  }
+
+  @inlinable
   public static func `case`<Values, Enum>(
     _ initializer: @escaping (Values) -> Enum
-  ) -> Self where Self == CasePath<Enum, Values> {
+  ) -> Self where Self == AnyCasePath<Enum, Values> {
     /initializer
   }
 
   @inlinable
   public static func `case`<Enum>(
     _ initializer: Enum
-  ) -> Self where Self == CasePath<Enum, Void> {
+  ) -> Self where Self == AnyCasePath<Enum, Void> {
     /initializer
   }
 }
 
-extension CasePath: Conversion {
+extension AnyCasePath: Conversion {
   @inlinable
   public func apply(_ input: Value) -> Root {
     self.embed(input)


### PR DESCRIPTION
Adds support for [case key paths](https://github.com/pointfreeco/swift-case-paths/pull/121). While parsers do not seem benefit from some features of case key paths (they can't be abbreviated), they can at least be used more performantly without the reflection associated with the old style of case paths.