### PR TITLE
Add SPI docs and fix outdated links in README

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Parsing]

--- a/README.md
+++ b/README.md
@@ -356,14 +356,16 @@ Xcode Logs.Parser                             4511625.500 ns ±   0.58 %        
 
 The documentation for releases and main are available here:
 
-* [main][swift-parsing-docs]
-* [0.10.0](https://pointfreeco.github.io/swift-parsing/0.10.0/documentation/parsing)
+* [latest release](https://swiftpackageindex.com/pointfreeco/swift-parsing/documentation)
+* [main](https://swiftpackageindex.com/pointfreeco/swift-parsing/documentation/main)
+  
 <details>
   <summary>
   Other versions
   </summary>
 
- * [0.9.0](https://pointfreeco.github.io/swift-parsing/0.9.0/documentation/parsing)
+  * [0.10.0](https://pointfreeco.github.io/swift-parsing/0.10.0/documentation/parsing)
+  * [0.9.0](https://pointfreeco.github.io/swift-parsing/0.9.0/documentation/parsing)
   * [0.8.0](https://pointfreeco.github.io/swift-parsing/0.8.0/documentation/parsing)
   * [0.7.1](https://pointfreeco.github.io/swift-parsing/0.7.1/documentation/parsing)
   * [0.7](https://pointfreeco.github.io/swift-parsing/0.7.0/documentation/parsing)


### PR DESCRIPTION
I don't want to force SPI hosted docs on you but I noticed that the doc links in the readme are outdated. This would generate the docs on SPI and make the README links essentially maintenance free.

Hope that helps!