### PR TITLE
Fix an error message StartsWith parser throws

### DIFF
--- a/Sources/Parsing/ParserPrinters/StartsWith.swift
+++ b/Sources/Parsing/ParserPrinters/StartsWith.swift
@@ -63,7 +63,7 @@ public struct StartsWith<Input: Collection>: Parser where Input.SubSequence == I
   @inlinable
   public func parse(_ input: inout Input) throws {
     guard self.startsWith(input) else {
-      throw ParsingError.expectedInput(formatValue(self.possiblePrefix), at: input)
+      throw ParsingError.expectedInput("\"\(formatValue(self.possiblePrefix))\"", at: input)
     }
     input.removeFirst(self.count)
   }

--- a/Sources/Parsing/ParsingError.swift
+++ b/Sources/Parsing/ParsingError.swift
@@ -415,6 +415,9 @@ func formatValue<Input>(
 
   case let input as Substring.UTF8View:
     return Substring(input).debugDescription
+    
+  case let input as AnyCollection<UInt8>:
+    return String(bytes: input, encoding: .utf8) ?? "\(input)"
 
   default:
     return "\(input)"

--- a/Tests/ParsingTests/StartsWithTests.swift
+++ b/Tests/ParsingTests/StartsWithTests.swift
@@ -7,4 +7,19 @@ final class StartsWithTests: XCTestCase {
     XCTAssertNoThrow(try StartsWith("Hello".utf8).parse(&str))
     XCTAssertEqual(", world!", Substring(str))
   }
+  
+  func testParseFailure() {
+    var input = "Goodnight, Blob!"[...].utf8
+    XCTAssertThrowsError(try StartsWith("Hello, ".utf8).parse(&input)) { error in
+      XCTAssertEqual(
+        """
+        error: unexpected input
+         --> input:1:1
+        1 | Goodnight, Blob!
+          | ^ expected "Hello, "
+        """,
+        "\(error)"
+      )
+    }
+  }
 }


### PR DESCRIPTION
## The Problem
StartsWith parser don't produce an error message as documented when failed. 

<img width="525" alt="스크린샷 2023-12-06 오전 1 52 04" src="https://github.com/pointfreeco/swift-parsing/assets/44376599/9aa69f7c-0c01-4a12-bcaf-6452012a16bd">

Above code produce a below error message which has a wired type presented at expected value position.
<img width="885" alt="스크린샷 2023-12-06 오전 1 49 05" src="https://github.com/pointfreeco/swift-parsing/assets/44376599/ef0916f8-e839-47d2-8bc3-39005906f56a">

## Causes
StartsWith parser hold possiblePrefix value as AnyCollection type, but the formatting method doesn't cover AnyCollection type.

## Fixs
In the formatting function, we handle a case where its input type is AnyCollection<UInt8>.
We use String(bytes:encoding:) initializer, so we don't need to care about invalid bytes input because it's failable. 