### PR TITLE
Take and/or TakeUpTo parsers

### DIFF
--- a/Sources/Parsing/ParserPrinters/Take.swift
+++ b/Sources/Parsing/ParserPrinters/Take.swift
@@ -1,0 +1,80 @@
+/// A parser that returns  input from the until the `terminator` `Parser`
+/// matches. This provides a method of "lazy" (as opposed to "greedy") consumption of the input.
+///
+/// ```swift
+/// enum ParkType {
+///   case park
+///   case world
+/// }
+///
+/// let lineParser: some Parser<Substring, (String, ParkType)> = Take {
+///   Prefix(0...).map(.string)
+/// } upTo: {
+///   OneOf {
+///     "Park".map { ParkType.park }
+///     "World".map { ParkType.world }
+///   }
+/// }
+///
+/// var input = "Jurrasic World"[...]
+/// let parsed = try line.parse(&input) // ("Jurrasic ", .world)
+/// ```
+public struct Take<Input: Collection, Taken: Parser, Terminator: Parser>: Parser
+  where Input.SubSequence == Input, Terminator.Input == Input, Taken.Input == Input {
+  public let taken: Taken
+  public let terminator: Terminator
+
+  @inlinable
+  public init(
+    @ParserBuilder<Input> _ taken: () -> Taken,
+    @ParserBuilder<Input> upTo terminator: () -> Terminator
+  ) {
+    self.taken = taken()
+    self.terminator = terminator()
+  }
+
+  @inlinable
+  @inline(__always)
+  public func parse(_ input: inout Input) throws -> (Taken.Output, Terminator.Output) {
+    let original = input
+
+    var currentIndex = input.startIndex
+    while currentIndex <= input.endIndex {
+      let terminatorOutput: Terminator.Output
+      var takenInput: Input
+
+      do {
+        var test = input[currentIndex...]
+        terminatorOutput = try terminator.parse(&test)
+        input = test
+        takenInput = original[..<currentIndex]
+      } catch {
+        guard currentIndex < input.endIndex else {
+          break
+        }
+        currentIndex = input.index(after: currentIndex)
+        continue
+      }
+
+      let takenOutput = try taken.parse(&takenInput)
+      guard takenInput.isEmpty else {
+        throw ParsingError.expectedInput("to match \(formatValue(terminator))", at: takenInput)
+      }
+      return (takenOutput, terminatorOutput)
+    }
+    throw ParsingError.expectedInput("take up to \(formatValue(terminator))", at: input)
+  }
+}
+
+extension Take: ParserPrinter where Input: PrependableCollection, Taken: ParserPrinter, Terminator: ParserPrinter {
+  @inlinable
+  public func print(_ output: Output, into input: inout Input) throws {
+    let (takenOutput, terminatorOutput) = output
+    try terminator.print(terminatorOutput, into: &input)
+    try taken.print(takenOutput, into: &input)
+  }
+}
+
+extension Parsers {
+  public typealias Take = Parsing.Take // NB: Convenience type alias for discovery
+}

--- a/Sources/Parsing/ParserPrinters/TakeUpTo.swift
+++ b/Sources/Parsing/ParserPrinters/TakeUpTo.swift
@@ -1,0 +1,66 @@
+/// A parser that consumes a subsequence from the beginning of its input until the `terminator` `Parser`
+/// matches. This provides a method of "lazy" (as opposed to "greedy") consumption of the input.
+///
+/// ```swift
+/// let lineParser = TakeUpTo {
+///   OneOf { "Park", "World" }
+/// }
+///
+/// var input = "Jurrasic World"[...]
+/// let parsed = try line.parse(&input) // ("Jurrasic ", "World")
+/// ```
+public struct TakeUpTo<Input: Collection, Upstream: Parser>: Parser
+where Input.SubSequence == Input, Upstream.Input == Input
+{
+  public let terminator: Upstream
+  
+  @inlinable
+  public init(
+    _ terminator: Upstream
+  ) {
+    self.terminator = terminator
+  }
+  
+  @inlinable
+  public init(
+    @ParserBuilder<Input> _ terminator: () -> Upstream
+  ) {
+    self.terminator = terminator()
+  }
+
+  @inlinable
+  @inline(__always)
+  public func parse(_ input: inout Input) throws -> (Input, Upstream.Output) {
+    let original = input
+    
+    var currentIndex = input.startIndex
+    while currentIndex <= input.endIndex {
+      do {
+        var test = input[currentIndex...]
+        let result = try terminator.parse(&test)
+        input = test
+        return (original[..<currentIndex], result)
+      } catch {
+        // do nothing
+      }
+      guard currentIndex < input.endIndex else {
+        break
+      }
+      currentIndex = input.index(after: currentIndex)
+    }
+    throw ParsingError.expectedInput("take up to \(formatValue(self.terminator))", at: input)
+  }
+}
+
+extension TakeUpTo: ParserPrinter where Input: PrependableCollection, Upstream: ParserPrinter {
+  @inlinable
+  public func print(_ output: Output, into input: inout Input) throws {
+    let (originalInput, terminatorOutput) = output
+    try terminator.print(terminatorOutput, into: &input)
+    input.prepend(contentsOf: originalInput)
+  }
+}
+
+extension Parsers {
+    public typealias TakeUpTo = Parsing.TakeUpTo  // NB: Convenience type alias for discovery
+}

--- a/Sources/Parsing/ParserPrinters/TakeUpTo.swift
+++ b/Sources/Parsing/ParserPrinters/TakeUpTo.swift
@@ -30,16 +30,16 @@ where Input.SubSequence == Input, Upstream.Input == Input
 
   @inlinable
   @inline(__always)
-  public func parse(_ input: inout Input) throws -> (Input, Upstream.Output) {
+  public func parse(_ input: inout Input) throws -> Input {
     let original = input
     
     var currentIndex = input.startIndex
     while currentIndex <= input.endIndex {
       do {
         var test = input[currentIndex...]
-        let result = try terminator.parse(&test)
-        input = test
-        return (original[..<currentIndex], result)
+        let _ = try terminator.parse(&test)
+        input = original[currentIndex...]
+        return original[..<currentIndex]
       } catch {
         // do nothing
       }
@@ -49,15 +49,6 @@ where Input.SubSequence == Input, Upstream.Input == Input
       currentIndex = input.index(after: currentIndex)
     }
     throw ParsingError.expectedInput("take up to \(formatValue(self.terminator))", at: input)
-  }
-}
-
-extension TakeUpTo: ParserPrinter where Input: PrependableCollection, Upstream: ParserPrinter {
-  @inlinable
-  public func print(_ output: Output, into input: inout Input) throws {
-    let (originalInput, terminatorOutput) = output
-    try terminator.print(terminatorOutput, into: &input)
-    input.prepend(contentsOf: originalInput)
   }
 }
 

--- a/Tests/ParsingTests/TakeTests.swift
+++ b/Tests/ParsingTests/TakeTests.swift
@@ -1,0 +1,94 @@
+import Parsing
+import XCTest
+
+final class TakeTests: XCTestCase {
+  func testIntAndVoid() throws {
+    let parser: some Parser<Substring, (Int, Void)> = Take {
+      Int.parser()
+    } upTo: {
+      "."
+    }
+
+    var input = "123.456"[...]
+    XCTAssertEqual(123, try parser.parse(&input).0)
+  }
+
+  func testUnterminated() throws {
+    let parser: some Parser<Substring, (Int, Void)> = Take {
+      Int.parser()
+    } upTo: {
+      "."
+    }
+
+    var input = "123456"[...]
+
+    XCTAssertThrowsError(try parser.parse(&input))
+  }
+
+  func testTakeStringAndInt() throws {
+    let parser: some Parser<Substring, (String, Int)> = Take {
+      Prefix(0...).map(.string)
+    } upTo: {
+      "456".map { 456 }
+    }
+
+    var input = "123456"[...]
+    let output = try parser.parse(&input)
+    XCTAssertEqual("123", output.0)
+    XCTAssertEqual(456, output.1)
+  }
+
+  func testTakeUpToEnd() throws {
+    let parser: some Parser<Substring, (Substring, ())> = Take {
+      Prefix(0...)
+    } upTo: {
+      End<Substring>()
+    }
+
+    var input = "123"[...]
+    XCTAssertEqual("123", try parser.parse(&input).0)
+    XCTAssertEqual("", input)
+  }
+
+  func testTakeCantParseUpTo() throws {
+    let parser: some Parser<Substring, (Int, ())> = Take {
+      Int.parser()
+    } upTo: {
+      End<Substring>()
+    }
+
+    var input = "123abc"[...]
+    XCTAssertThrowsError(try parser.parse(&input))
+  }
+
+  func testComplextInitMap() throws {
+    enum Example: Equatable {
+      case a
+      case b
+    }
+
+    struct ComplexType: Equatable {
+      let string: String
+      let number: Int
+      let example: Example?
+    }
+
+    let parser: some Parser<Substring, ComplexType> = Parse(ComplexType.init(string:number:example:)) {
+      Take {
+        Prefix(0...).map(.string)
+      } upTo: {
+        Int.parser()
+      }
+      Optionally {
+        OneOf {
+          "a".map { Example.a }
+          "b".map { Example.b }
+        }
+      }
+    }
+    
+    var input = "Hello1b"[...]
+    XCTAssertEqual(ComplexType(string: "Hello", number: 1, example: .b), try parser.parse(&input))
+    XCTAssertTrue(input.isEmpty)
+  }
+}

--- a/Tests/ParsingTests/TakeUpToTests.swift
+++ b/Tests/ParsingTests/TakeUpToTests.swift
@@ -8,7 +8,8 @@ final class TakeUpToTests: XCTestCase {
     }
 
     var input = "123.456"[...]
-    XCTAssertEqual("123", try parser.parse(&input).0)
+    XCTAssertEqual("123", try parser.parse(&input))
+    XCTAssertEqual(".456", input)
   }
 
   func testUnterminated() throws {
@@ -27,8 +28,8 @@ final class TakeUpToTests: XCTestCase {
     }
     var input = "123456"[...]
     let output = try parser.parse(&input)
-    XCTAssertEqual("123", output.0)
-    XCTAssertEqual(456, output.1)
+    XCTAssertEqual("123", output)
+    XCTAssertEqual("456", input)
   }
 
   func testTakeSubstring() throws {
@@ -37,9 +38,8 @@ final class TakeUpToTests: XCTestCase {
     }
     var input = "123456"[...]
     let output = try parser.parse(&input)
-    XCTAssertEqual("123", output.0)
-    XCTAssertEqual(456, output.1)
-    XCTAssertEqual("", input)
+    XCTAssertEqual("123", output)
+    XCTAssertEqual("456", input)
   }
 
   func testTakeUpToEnd() throws {
@@ -48,7 +48,7 @@ final class TakeUpToTests: XCTestCase {
     }
 
     var input = "123"[...]
-    XCTAssertEqual("123", try parser.parse(&input).0)
-    XCTAssertEqual("", input)
+    XCTAssertEqual("123", try parser.parse(&input))
+    XCTAssertTrue(input.isEmpty)
   }
 }

--- a/Tests/ParsingTests/TakeUpToTests.swift
+++ b/Tests/ParsingTests/TakeUpToTests.swift
@@ -1,0 +1,54 @@
+import Parsing
+import XCTest
+
+final class TakeUpToTests: XCTestCase {
+  func testSimple() throws {
+    let parser = TakeUpTo {
+      "."
+    }
+
+    var input = "123.456"[...]
+    XCTAssertEqual("123", try parser.parse(&input).0)
+  }
+
+  func testUnterminated() throws {
+    let parser = TakeUpTo {
+      "."
+    }
+
+    var input = "123456"[...]
+
+    XCTAssertThrowsError(try parser.parse(&input))
+  }
+
+  func testTakeUpToString() throws {
+    let parser = TakeUpTo {
+      "456".map { 456 }
+    }
+    var input = "123456"[...]
+    let output = try parser.parse(&input)
+    XCTAssertEqual("123", output.0)
+    XCTAssertEqual(456, output.1)
+  }
+
+  func testTakeSubstring() throws {
+    let parser = TakeUpTo {
+      "456".map { 456 }
+    }
+    var input = "123456"[...]
+    let output = try parser.parse(&input)
+    XCTAssertEqual("123", output.0)
+    XCTAssertEqual(456, output.1)
+    XCTAssertEqual("", input)
+  }
+
+  func testTakeUpToEnd() throws {
+    let parser = TakeUpTo {
+      End<Substring>()
+    }
+
+    var input = "123"[...]
+    XCTAssertEqual("123", try parser.parse(&input).0)
+    XCTAssertEqual("", input)
+  }
+}


### PR DESCRIPTION
This is a pitch for adding one  or possibly both parsers to the core library. There is nothing in the library that currently lets you do what these do. They are both achieving the same basic goal with a slightly different approach.

They were inspired by [this thread](https://pointfreecommunity.slack.com/archives/C04L57GCR99/p1710773714913839) in Slack, and I figured the solution might be worth sharing.

For example, the goal from the thread was parsing episode names. This is a simpler example, with a standard format of "<name> - Ep <number>".

This is actually quite hard to parse right now, since name could contain anything (including "-", digits, etc). The main rule is that it always ends with " - <number>". For example, "Testing, 1, 2, 3 - a Brief History - Ep 2".

```swift
struct EpisodeTitle {
  let name: String
  let number: Int
}
```

# `Take`

The `Take` parser is provided with two parsers: a 'taker' and a 'terminator'. The results for both are returned as a tuple. Here's how it would parse `EpisodeTitle`:

```swift
let parser: some Parser<Substring, EpisodeTitle> = Parse(EpisodeTitle.init) {
  Take {
    Prefix(1...).map(.string)
  } upTo: {
    " - "
    Int.parser()
    End()
  }
}

let episodeTitle = try parser.parse("Testing, 1, 2, 3 - a Brief History - Ep 2")
```

Because `Take`'s output is a tuple, it's signature looks like this in our example:

```swift
let takeParser: some Parser<Substring, (String, Int)> =   Take {
  Prefix(1...).map(.string)
} upTo: {
  " - "
  Int.parser()
  End()
}
```

This is a bit odd, but does generally boil down into single-level tuples thanks to how parsers work in the library.

# `TakeUpTo`

This variant just lets you specify the `terminator` `Parser`, and anything before that is returned unmodified.

This is a somewhat simpler implementation, but with the key limitation that it doesn't let you have any complex parsing _before_ the terminator. Also, it because it doesn't return the value parsed by the terminator, it can't return that value either, so it has to be parsed again.

For example:

```swift
let parser: some Parser<Substring, EpisodeTitle> = Parse(EpisodeTitle.init) {
  TakeUpTo {
    " - "
    Int.parser()
    End()
  }.map(.string)
  " - "
  Int.parser()
  End()
}

let episodeTitle = try parser.parse("Testing, 1, 2, 3 - a Brief History - Ep 2")
```

# Alternate approaches

I was unable to find anything which would allow parsing in situations like this, but I might have missed something. I attempted to use:

```swift
Parser(Episode.init) {
  Many {
    Prefix(1)
  } terminator: {
    " - "
    Int.parser()
    End()
  }.map(.string)
  " - "
  Int.parser()
  End()
}
```

However, `Many` doesn't actively check the terminator - it just checks if the next input matches the terminator once the main parser stops matching. As such, just eats all the text, including the episode details.

Anyway, would like to hear your thoughts. Of the two, `Take` is more flexible, but also more complicated, and still has some rough edges I'd like to sand off.