### PR TITLE
Provide more type information on the JSONObject Parser

### DIFF
--- a/Sources/swift-parsing-benchmark/JSON.swift
+++ b/Sources/swift-parsing-benchmark/JSON.swift
@@ -70,7 +70,10 @@ let jsonSuite = BenchmarkSuite(name: "JSON") { suite in
     struct JSONObject: ParserPrinter {
       var body: some ParserPrinter<Substring.UTF8View, [String: JSONValue.Output]> {
         "{".utf8
-        Many(into: [String: JSONValue.Output]()) { object, pair in
+        Many(into: [String: JSONValue.Output]()) { (
+          object: inout [String: JSONValue.Output],
+          pair: (String, JSONValue.Output)
+        ) in
           let (name, value) = pair
           object[name] = value
         } decumulator: { object in

--- a/Tests/ParsingTests/OneOfTests.swift
+++ b/Tests/ParsingTests/OneOfTests.swift
@@ -271,7 +271,10 @@ final class OneOfTests: XCTestCase {
       struct JSONObject: ParserPrinter {
         var body: some ParserPrinter<Substring.UTF8View, [String: JSONValue.Output]> {
           "{".utf8
-          Many(into: [String: JSONValue.Output]()) { object, pair in
+          Many(into: [String: JSONValue.Output]()) { (
+            object: inout [String: JSONValue.Output],
+            pair: (String, JSONValue.Output)
+          ) in
             let (name, value) = pair
             object[name] = value
           } decumulator: { object in


### PR DESCRIPTION
Hi,
This PR Fixes an issue when building for XCode 15.3 where the compiler is not able to provide a diagnostic.
Type information has been explicitly provided to help the compiler.

Two files have been updated:
- [Sources/swift-parsing-benchmark/JSON.swift](https://github.com/pointfreeco/swift-parsing/blob/main/Sources/swift-parsing-benchmark/JSON.swift)
- [Tests/ParsingTests/OneOfTests.swift](https://github.com/pointfreeco/swift-parsing/blob/main/Tests/ParsingTests/OneOfTests.swift)