### PR TITLE
Fixed non throwing parsers crash

### DIFF
--- a/Sources/Parsing/Parser.swift
+++ b/Sources/Parsing/Parser.swift
@@ -168,7 +168,7 @@ extension Parser {
   /// - Parameter input: A nebulous collection of data to be parsed.
   /// - Returns: A more well-structured value parsed from the given input.
   @inlinable
-  public func parse<C: Collection>(_ input: C) rethrows -> Output
+  public func parse<C: Collection>(_ input: C) throws -> Output
   where Input == C.SubSequence {
     var input = input[...]
     return try Parse {
@@ -238,7 +238,7 @@ extension Parser {
   /// - Returns: A more well-structured value parsed from the given input.
   @_disfavoredOverload
   @inlinable
-  public func parse<S: StringProtocol>(_ input: S) rethrows -> Output
+  public func parse<S: StringProtocol>(_ input: S) throws -> Output
   where Input == S.SubSequence.UTF8View {
     var input = input[...].utf8
     return try Parse {

--- a/Sources/Parsing/ParserPrinters/Consumed.swift
+++ b/Sources/Parsing/ParserPrinters/Consumed.swift
@@ -22,7 +22,7 @@ where
 
 extension Consumed: ParserPrinter where Upstream.Input: PrependableCollection {
   @inlinable
-  public func print(_ output: Upstream.Input, into input: inout Upstream.Input) rethrows {
+  public func print(_ output: Upstream.Input, into input: inout Upstream.Input) throws {
     do {
       _ = try self.upstream.parse(output)
       input.prepend(contentsOf: output)

--- a/Tests/ParsingTests/ParserTests.swift
+++ b/Tests/ParsingTests/ParserTests.swift
@@ -15,4 +15,56 @@ final class ParserTests: XCTestCase {
       )
     }
   }
+
+  func testNonThrowingParserParseCollectionSuccess() throws {
+    let p = Parse { CharacterSet(charactersIn: "abc") }
+    XCTAssertEqual("abacab", try p.parse("abacab"))
+  }
+
+  func testNonThrowingParserParseCollectionFailure() {
+    let p = Parse { CharacterSet(charactersIn: "abc") }
+    XCTAssertThrowsError(try p.parse("abacad")) { error in
+      XCTAssertEqual(
+        """
+        error: unexpected input
+         --> input:1:6
+        1 | abacad
+          |      ^ expected end of input
+        """,
+        "\(error)"
+      )
+    }
+  }
+
+  func testNonThrowingParserParseStringToUTF8ViewSuccess() {
+    enum Currency { case eur, gbp, usd, unknown }
+    let p = OneOf {
+      "€".utf8.map { Currency.eur }
+      "£".utf8.map { Currency.gbp }
+      "$".utf8.map { Currency.usd }
+    }
+    .replaceError(with: Currency.unknown)
+    XCTAssertEqual(Currency.usd, try p.parse("$"))
+  }
+
+  func testNonThrowingParserParseStringToUTF8ViewFailure() {
+    enum Currency { case eur, gbp, usd, unknown }
+    let p = OneOf {
+      "€".utf8.map { Currency.eur }
+      "£".utf8.map { Currency.gbp }
+      "$".utf8.map { Currency.usd }
+    }
+    .replaceError(with: Currency.unknown)
+    XCTAssertThrowsError(try p.parse("฿")) { error in
+      XCTAssertEqual(
+        """
+        error: unexpected input
+         --> input:1:1
+        1 | ฿
+          | ^ expected end of input
+        """,
+        "\(error)"
+      )
+    }
+  }
 }


### PR DESCRIPTION
The [`End`](https://github.com/pointfreeco/swift-parsing/blob/f949081268f1f67f2cbc6e4f13a1494f6bcb0cd2/Sources/Parsing/ParserPrinters/End.swift#L19) parser that is used in `parse` functions ([1](https://github.com/pointfreeco/swift-parsing/blob/main/Sources/Parsing/Parser.swift#L171), [2](https://github.com/pointfreeco/swift-parsing/blob/main/Sources/Parsing/Parser.swift#L241)) can throw errors, but due to a bug in the swift compiler, it was possible to call the `parse` functions without the `try` keyword for non-throwing parsers that cannot throw errors.

Issues:
- https://github.com/pointfreeco/swift-parsing/issues/333
- https://github.com/pointfreeco/swift-parsing/issues/328

