### PR TITLE
Fixed Playground compilation error

### DIFF
--- a/Parsing.playground/Contents.swift
+++ b/Parsing.playground/Contents.swift
@@ -53,20 +53,20 @@ struct Instructions {
 
 // MARK: - Parsers
 
-let dot = ParsePrint(.memberwise(Dot.init)) {
+let dot = ParsePrint(input: Substring.self, .memberwise(Dot.init)) {
   Digits()
   ","
   Digits()
 }
 
-let fold = ParsePrint(.memberwise(Fold.init)) {
+let fold = ParsePrint(input: Substring.self, .memberwise(Fold.init)) {
   "fold along "
   Direction.parser()
   "="
   Digits()
 }
 
-let instructions = ParsePrint(.memberwise(Instructions.init)) {
+let instructions = ParsePrint(input: Substring.self, .memberwise(Instructions.init)) {
   Many {
     dot
   } separator: {

--- a/Parsing.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Parsing.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "bb436421f57269fbcfe7360735985321585a86e5",
-        "version" : "0.10.1"
+        "revision" : "642e6aab8e03e5f992d9c83e38c5be98cfad5078",
+        "version" : "1.5.5"
       }
     },
     {
@@ -34,6 +34,24 @@
       "state" : {
         "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "bc2a151366f2cd0e347274544933bc2acb00c9fe",
+        "version" : "1.4.0"
       }
     }
   ],


### PR DESCRIPTION
Playground example had a compilation error due to some changes in Swift Parsing.

Using the ParsePrint with input initialiser fixes the problem

Related issue: https://github.com/pointfreeco/swift-parsing/issues/349