### PR TITLE
Don't use input.count in PrefixThrough and PrefixUpTo for speedup.

### DIFF
--- a/Sources/Parsing/ParserPrinters/PrefixThrough.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixThrough.swift
@@ -32,12 +32,11 @@ public struct PrefixThrough<Input: Collection>: Parser where Input.SubSequence =
     let original = input
     while let index = input.firstIndex(where: { self.areEquivalent(first, $0) }) {
       input = input[index...]
-      if input.count >= count,
-        zip(input[index...], self.possibleMatch).allSatisfy(self.areEquivalent)
+      if let matchEndIndex = input.index(index, offsetBy: count, limitedBy: input.endIndex),
+        zip(input[..<matchEndIndex], self.possibleMatch).allSatisfy(self.areEquivalent)
       {
-        let index = input.index(index, offsetBy: count)
-        input = input[index...]
-        return original[..<index]
+        input = input[matchEndIndex...]
+        return original[..<matchEndIndex]
       }
       input.removeFirst()
     }

--- a/Sources/Parsing/ParserPrinters/PrefixUpTo.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixUpTo.swift
@@ -32,8 +32,8 @@ public struct PrefixUpTo<Input: Collection>: Parser where Input.SubSequence == I
     let original = input
     while let index = input.firstIndex(where: { self.areEquivalent(first, $0) }) {
       input = input[index...]
-      if input.count >= count,
-        zip(input[index...], self.possibleMatch).allSatisfy(self.areEquivalent)
+      if let matchEndIndex = input.index(index, offsetBy: count, limitedBy: input.endIndex),
+        zip(input[..<matchEndIndex], self.possibleMatch).allSatisfy(self.areEquivalent)
       {
         return original[..<index]
       }


### PR DESCRIPTION
I have made a simple HTML tokenizer and noticed using Instruments that `PrefixThrough` was spending a lot of time in `Substring.count`, which in turn was calling `distance(from:to:)`. I assume this is because the character count of a substring isn't known until calculated due to how Unicode works. This patch replaces the substring count check with a match end index check instead.

I was unable to make sense of the results from the benchmark app, but in my HTML project (link provided) there was a substantial speedup. In that repo there is a benchmark app in the branch `swift-parsing`, and you can switch between swift-parsing versions in `Package.swift`.

https://github.com/BjornRuud/HTMLLexer.git
