### PR TITLE
Fix a mistake in docs

### DIFF
--- a/Sources/Parsing/Builders/OneOfBuilder.swift
+++ b/Sources/Parsing/Builders/OneOfBuilder.swift
@@ -14,7 +14,7 @@
 /// }
 /// let money = Parse { currency; Digits() }
 ///
-/// try currency.parse("$100") // (.usd, 100)
+/// try money.parse("$100") // (.usd, 100)
 /// ```
 @resultBuilder
 public enum OneOfBuilder<Input, Output> {

--- a/Sources/Parsing/ParserPrinters/Printing.swift
+++ b/Sources/Parsing/ParserPrinters/Printing.swift
@@ -7,14 +7,14 @@ extension Parser {
   /// a single space:
   ///
   /// ```swift
-  /// let spaces = Skip { Prefix { $0.isWhitespace } }.printing(" ")
+  /// let spaces = Skip { Prefix(while: \.isWhitespace) }.printing(" ")
   ///
   /// var input = "     123"[...]
   /// try spaces.parse(&input)  // ()
   /// input                     // "123"
   ///
-  /// spaces.print(to: &input)
-  /// input                     // "123 "
+  /// try spaces.print(into: &input)
+  /// input                     // " 123"
   /// ```
   ///
   /// - Parameter printer: A printer.


### PR DESCRIPTION
The most important change is '123 ' --> ' 123' (the whitespace is in front, not behind).
That was quite misleading 😃