### PR TITLE
Add `Indexed` parser

### DIFF
--- a/Sources/Parsing/ParserPrinters/Indexed.swift
+++ b/Sources/Parsing/ParserPrinters/Indexed.swift
@@ -1,0 +1,31 @@
+extension Parsers {
+  /// A parser of a collection that returns a base parser's output as well as the index range of the
+  /// parsed input.
+  public struct Indexed<Base>: Parser
+  where Base: Parser, Base.Input: Collection {
+    public let base: Base
+
+    @inlinable
+    init(_ base: Base) {
+      self.base = base
+    }
+
+    @inlinable
+    public func parse(
+      _ input: inout Base.Input
+    ) throws -> (output: Base.Output, indices: Range<Base.Input.Index>) {
+      let startIndex = input.startIndex
+      let output = try base.parse(&input)
+      return (output, startIndex..<input.startIndex)
+    }
+  }
+}
+
+extension Parser where Input: Collection {
+  /// A parser of a collection that returns a base parser's output as well as the index range of the
+  /// parsed input.
+  @inlinable
+  public func indexed() -> Parsers.Indexed<Self> {
+    Parsers.Indexed(self)
+  }
+}

--- a/Tests/ParsingTests/IndexedTests.swift
+++ b/Tests/ParsingTests/IndexedTests.swift
@@ -1,0 +1,46 @@
+import Parsing
+import XCTest
+
+private struct Output: Equatable {
+  var username: Substring
+  var range: Range<String.Index>
+}
+
+final class IndexedTests: XCTestCase {
+  func testStringHappyPath() throws {
+    let input = "Hi @BlobJr; please call @BlobSr when you get a chance. Thanks."
+    let parser: some Parser<Substring.UTF8View, [Output]> = Many {
+      Skip {
+        PrefixUpTo("@".utf8)
+      }
+
+      From(.substring) {
+        Parse {
+          "@"
+
+          Prefix(while: { $0.isLetter || $0.isNumber })
+        }
+        .indexed()
+      }
+      .map(Output.init)
+    } terminator: {
+      Rest()
+    }
+    let usernames = try parser.parse(input)
+    XCTAssertEqual(
+      usernames,
+      [
+        Output(
+          username: "BlobJr",
+          range: input
+            .index(input.startIndex, offsetBy: 3)..<input.index(input.startIndex, offsetBy: 10)
+        ),
+        Output(
+          username: "BlobSr",
+          range: input
+            .index(input.startIndex, offsetBy: 24)..<input.index(input.startIndex, offsetBy: 31)
+        )
+      ]
+    )
+  }
+}


### PR DESCRIPTION
Based on [this discussion](https://github.com/pointfreeco/swift-parsing/discussions/69), I've sketched this parser. Didn't seem to make much sense to me as a printer, but happy to look at revising it. Let me know if you think it'd be useful to have in the library proper or if it should maybe just stay as an ad hoc extension?