### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  macos:
+  macos15:
+    name: macOS (Swift 6)
+    runs-on: macos-15
+    strategy:
+      matrix:
+        xcode:
+          - '16.2'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: System
+        run: system_profiler SPHardwareDataType
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test
+
+  macos14:
+    name: macOS (Swift 5.9)
     runs-on: macos-14
     strategy:
       matrix:
         xcode:
-          - '16.0'
+          - '15.2'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}
@@ -28,6 +47,7 @@ jobs:
         run: swift test
 
   linux:
+    name: Linux
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
GitHub dropped Xcode 16 in favor of 16.2, so let's update our CI.