### PR TITLE
Add Parse extension for conversion initializer

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: [coenttb]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/metadata.yaml
+++ b/.github/metadata.yaml
@@ -1,0 +1,11 @@
+# .github/metadata.yaml
+description: "A fork of pointfreeco/swift-parsing."
+homepage: "https://swift-institute.org"
+topics:
+  - combinators
+  - fork
+  - parsing
+  - pointfree
+  - swift
+readme:
+  family: E

--- a/Sources/Parsing/Conversion.swift
+++ b/Sources/Parsing/Conversion.swift
@@ -26,3 +26,12 @@
   /// - Returns: An "un"-transformed input value.
   func unapply(_ output: Output) throws -> Input
 }
+
+extension Parse {
+  @inlinable
+  public init<Downstream>(
+    _ conversion: Downstream
+  ) where Parsers == Parsing.Parsers.MapConversion<Rest<Downstream.Input>, Downstream> {
+    self.init { Rest().map(conversion) }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a convenience initializer to Parse that accepts a conversion and applies it to the rest of the input
- This extension was originally in the URLRouting library but is better placed here as it's not specific to URL routing
- All tests pass with this change

## Test plan
- [x] All existing tests continue to pass
- [x] The new extension compiles successfully and integrates with existing functionality