### PR TITLE
WIP: Migrate to Swift 6 and Strict Concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,42 @@ generate-variadics:
 		--generate-one-ofs \
 		> Sources/Parsing/Builders/Variadics.swift
 
+
+# MARK: - Swift Compiler build tests
+
+DOCKER_CMD = \
+	docker run \
+	--rm \
+	-v $(PWD):/host \
+	-w "/host"
+
+TEST_SCRIPT = bash -c "\
+	cd ..; \
+	cp -r host container; \
+	cd container; \
+	swift package clean; \
+	swift test --parallel; \
+	"
+
+test-5-9:
+	$(DOCKER_CMD) \
+	swift:5.9.2 \
+	$(TEST_SCRIPT)
+
+test-5-10:
+	$(DOCKER_CMD) \
+	swift:5.10.1 \
+	$(TEST_SCRIPT)
+
+test-6-0:
+	$(DOCKER_CMD) \
+	swift:6.0.3 \
+	$(TEST_SCRIPT)
+
+test-latest:
+	$(DOCKER_CMD) \
+	swift:latest \
+	$(TEST_SCRIPT)
+
+
 .PHONY: benchmarks format generate-variadics test

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let swift6Settings: [SwiftSetting] = [
   .enableUpcomingFeature("StrictConcurrency"),
   .enableUpcomingFeature("ExistentialAny"),
   .enableUpcomingFeature("MemberImportVisibility"),
-//  .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+//  .enableUpcomingFeature("NonisolatedNonsendingByDefault"), // should not matter, package doesn't use Concurrency yet
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         "Parsing",
         .product(name: "Benchmark", package: "swift-benchmark"),
       ],
-      swiftSettings: swift6Settings,
+//      swiftSettings: swift6Settings,
     ),
     .testTarget(
       name: "Swift6Tests",

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,12 @@
 
 import PackageDescription
 
+// For migration to Swift 6
+let swift6Settings: [SwiftSetting] = [
+//  .enableUpcomingFeature("StrictConcurrency"),
+  .enableUpcomingFeature("ExistentialAny"),
+]
+
 let package = Package(
   name: "swift-parsing",
   platforms: [
@@ -13,7 +19,7 @@ let package = Package(
   products: [
     .library(
       name: "Parsing",
-      targets: ["Parsing"]
+      targets: ["Parsing"],
     )
   ],
   dependencies: [
@@ -24,20 +30,30 @@ let package = Package(
   targets: [
     .target(
       name: "Parsing",
-      dependencies: [.product(name: "CasePaths", package: "swift-case-paths")]
+      dependencies: [.product(name: "CasePaths", package: "swift-case-paths")],
+      swiftSettings: swift6Settings,
     ),
     .testTarget(
       name: "ParsingTests",
       dependencies: [
-        "Parsing"
-      ]
+        "Parsing",
+      ],
+      swiftSettings: swift6Settings,
     ),
     .executableTarget(
       name: "swift-parsing-benchmark",
       dependencies: [
         "Parsing",
         .product(name: "Benchmark", package: "swift-benchmark"),
-      ]
+      ],
+      swiftSettings: swift6Settings,
     ),
-  ]
+    .testTarget(
+      name: "Swift6Tests",
+      dependencies: [
+        "Parsing",
+      ],
+      swiftSettings: swift6Settings,
+    )
+  ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let swift6Settings: [SwiftSetting] = [
   .enableUpcomingFeature("StrictConcurrency"),
   .enableUpcomingFeature("ExistentialAny"),
-//  .enableUpcomingFeature("MemberImportVisibility"),
+  .enableUpcomingFeature("MemberImportVisibility"),
 //  .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,8 @@ import PackageDescription
 let swift6Settings: [SwiftSetting] = [
   .enableUpcomingFeature("StrictConcurrency"),
   .enableUpcomingFeature("ExistentialAny"),
+//  .enableUpcomingFeature("MemberImportVisibility"),
+//  .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
 ]
 
 let package = Package(
@@ -46,7 +48,7 @@ let package = Package(
         "Parsing",
         .product(name: "Benchmark", package: "swift-benchmark"),
       ],
-//      swiftSettings: swift6Settings,
+      swiftSettings: swift6Settings,
     ),
     .testTarget(
       name: "Swift6Tests",

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 // For migration to Swift 6
 let swift6Settings: [SwiftSetting] = [
-//  .enableUpcomingFeature("StrictConcurrency"),
+  .enableUpcomingFeature("StrictConcurrency"),
   .enableUpcomingFeature("ExistentialAny"),
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
   products: [
     .library(
       name: "Parsing",
-      targets: ["Parsing"],
+      targets: ["Parsing"]
     )
   ],
   dependencies: [
@@ -33,14 +33,14 @@ let package = Package(
     .target(
       name: "Parsing",
       dependencies: [.product(name: "CasePaths", package: "swift-case-paths")],
-      swiftSettings: swift6Settings,
+      swiftSettings: swift6Settings
     ),
     .testTarget(
       name: "ParsingTests",
       dependencies: [
         "Parsing",
       ],
-      swiftSettings: swift6Settings,
+      swiftSettings: swift6Settings
     ),
     .executableTarget(
       name: "swift-parsing-benchmark",
@@ -48,14 +48,14 @@ let package = Package(
         "Parsing",
         .product(name: "Benchmark", package: "swift-benchmark"),
       ],
-      swiftSettings: swift6Settings,
+      swiftSettings: swift6Settings
     ),
     .testTarget(
       name: "Swift6Tests",
       dependencies: [
         "Parsing",
       ],
-      swiftSettings: swift6Settings,
+      swiftSettings: swift6Settings
     )
-  ],
+  ]
 )

--- a/Sources/Parsing/Conversions/AnyConversion.swift
+++ b/Sources/Parsing/Conversions/AnyConversion.swift
@@ -105,6 +105,7 @@ extension Conversion {
 ///
 /// If performance is a consideration of your parser-printer, you should avoid `AnyConversion` and
 /// instead create custom types that conform to the ``Conversion`` protocol.
+@preconcurrency // TODO: Would be Sendable if _apply and _unapply where also @Sendable
 public struct AnyConversion<Input, Output>: Conversion {
   @usableFromInline
   let _apply: (Input) throws -> Output

--- a/Sources/Parsing/Conversions/BinaryFloatingPoint.swift
+++ b/Sources/Parsing/Conversions/BinaryFloatingPoint.swift
@@ -45,7 +45,7 @@ extension Conversions {
   /// the ``Conversion/double-swift.type.property`` operation, which constructs this type.
   public struct FixedWidthIntegerToBinaryFloatingPoint<
     Input: FixedWidthInteger, Output: BinaryFloatingPoint
-  >: Conversion {
+  >: Conversion, Sendable {
     @usableFromInline
     init() {}
 

--- a/Sources/Parsing/Conversions/ConversionMap.swift
+++ b/Sources/Parsing/Conversions/ConversionMap.swift
@@ -52,3 +52,5 @@ extension Conversions {
     }
   }
 }
+
+extension Conversions.Map: Sendable where Upstream: Sendable, Downstream: Sendable { }

--- a/Sources/Parsing/Conversions/Data.swift
+++ b/Sources/Parsing/Conversions/Data.swift
@@ -38,7 +38,7 @@ extension Conversions {
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Conversion/data-swift.type.property-8z7qz`` and
   /// ``Conversion/data-swift.type.property-7g9sj`` operations, which constructs this type.
-  public struct BytesToData<Input: PrependableCollection>: Conversion where Input.Element == UInt8 {
+  public struct BytesToData<Input: PrependableCollection>: Conversion, Sendable where Input.Element == UInt8 {
     @usableFromInline
     init() {}
 

--- a/Sources/Parsing/Conversions/FixedWidthInteger.swift
+++ b/Sources/Parsing/Conversions/FixedWidthInteger.swift
@@ -37,7 +37,7 @@ extension Conversions {
   /// the ``Conversion/int-swift.type.property`` operation, which constructs this type.
   public struct BinaryFloatingPointToFixedWidthInteger<
     Input: BinaryFloatingPoint, Output: FixedWidthInteger
-  >: Conversion {
+  >: Conversion, Sendable {
     @usableFromInline
     init() {}
 

--- a/Sources/Parsing/Conversions/Identity.swift
+++ b/Sources/Parsing/Conversions/Identity.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Conversions {
-  public struct Identity<Value>: Conversion {
+  public struct Identity<Value>: Conversion, Sendable {
     @inlinable
     public init() {}
 

--- a/Sources/Parsing/Conversions/JSON.swift
+++ b/Sources/Parsing/Conversions/JSON.swift
@@ -52,7 +52,7 @@ extension Conversions {
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Conversion/json(_:decoder:encoder:)-swift.type.method`` operation, which constructs this
   /// type.
-  public struct JSON<Value: Codable>: Conversion {
+  public struct JSON<Value: Codable>: Conversion, Sendable {
     @usableFromInline
     let decoder: JSONDecoder
 

--- a/Sources/Parsing/Conversions/LosslessStringConvertible.swift
+++ b/Sources/Parsing/Conversions/LosslessStringConvertible.swift
@@ -40,7 +40,7 @@ extension Conversions {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Conversion/lossless(_:)-swift.type.method`` operation, which constructs this type.
-  public struct FromLosslessString<Output: LosslessStringConvertible>: Conversion {
+  public struct FromLosslessString<Output: LosslessStringConvertible>: Conversion, Sendable {
     @usableFromInline
     init() {}
 

--- a/Sources/Parsing/Conversions/Memberwise.swift
+++ b/Sources/Parsing/Conversions/Memberwise.swift
@@ -124,6 +124,8 @@ extension Conversion {
 }
 
 extension Conversions {
+  
+  @preconcurrency // Sendable when initializer is Sendable
   public struct Memberwise<Values, Struct>: Conversion {
     @usableFromInline
     let initializer: (Values) -> Struct

--- a/Sources/Parsing/Conversions/ParseableFormatStyleConversion.swift
+++ b/Sources/Parsing/Conversions/ParseableFormatStyleConversion.swift
@@ -62,4 +62,7 @@
       }
     }
   }
+  
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  extension Conversions.ParseableFormat: Sendable where Style: Sendable { }
 #endif

--- a/Sources/Parsing/Conversions/RawRepresentable.swift
+++ b/Sources/Parsing/Conversions/RawRepresentable.swift
@@ -77,7 +77,7 @@ extension Conversions {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Conversion/representing(_:)-swift.type.method`` operation, which constructs this type.
-  public struct FromRawValue<Output: RawRepresentable>: Conversion {
+  public struct FromRawValue<Output: RawRepresentable>: Conversion, Sendable {
     @inlinable
     public init() {}
 

--- a/Sources/Parsing/Conversions/String.swift
+++ b/Sources/Parsing/Conversions/String.swift
@@ -44,7 +44,7 @@ extension Conversions {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Conversion/string-swift.type.property-3u2b5`` operation, which constructs this type.
-  public struct SubstringToString: Conversion {
+  public struct SubstringToString: Conversion, Sendable {
     @inlinable
     public init() {}
 
@@ -63,7 +63,7 @@ extension Conversions {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Conversion/string-swift.type.property-9owth`` operation, which constructs this type.
-  public struct BytesToString<Input: PrependableCollection>: Conversion
+  public struct BytesToString<Input: PrependableCollection>: Conversion, Sendable
   where
     Input.SubSequence == Input,
     Input.Element == UTF8.CodeUnit

--- a/Sources/Parsing/Conversions/Substring.swift
+++ b/Sources/Parsing/Conversions/Substring.swift
@@ -53,7 +53,7 @@ extension Conversions {
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Conversion/substring-swift.type.property-1y3u3`` and operation, which constructs this
   /// type under the hood.
-  public struct UnicodeScalarViewToSubstring: Conversion {
+  public struct UnicodeScalarViewToSubstring: Conversion, Sendable {
     @inlinable
     public init() {}
 

--- a/Sources/Parsing/Conversions/UTF8View.swift
+++ b/Sources/Parsing/Conversions/UTF8View.swift
@@ -20,7 +20,7 @@ extension Conversions {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Conversion/utf8-swift.type.property`` operation, which constructs this type.
-  public struct SubstringToUTF8View: Conversion {
+  public struct SubstringToUTF8View: Conversion, Sendable {
     @inlinable
     public init() {}
 

--- a/Sources/Parsing/Internal/AnyEquatable.swift
+++ b/Sources/Parsing/Internal/AnyEquatable.swift
@@ -1,7 +1,7 @@
 @usableFromInline
 func isEqual(_ lhs: Any, _ rhs: Any) -> Bool {
   func open<LHS>(_: LHS.Type) -> Bool? {
-    (Box<LHS>.self as? AnyEquatable.Type)?.isEqual(lhs, rhs)
+    (Box<LHS>.self as? (any AnyEquatable.Type))?.isEqual(lhs, rhs)
   }
   return _openExistential(type(of: lhs), do: open) ?? false
 }

--- a/Sources/Parsing/ParserPrinters/Always.swift
+++ b/Sources/Parsing/ParserPrinters/Always.swift
@@ -81,3 +81,5 @@ public struct Always<Input, Output>: ParserPrinter {
 extension Parsers {
   public typealias Always = Parsing.Always  // NB: Convenience type alias for discovery
 }
+
+extension Always: Sendable where Output: Sendable { }

--- a/Sources/Parsing/ParserPrinters/AnyParserPrinter.swift
+++ b/Sources/Parsing/ParserPrinters/AnyParserPrinter.swift
@@ -25,6 +25,7 @@ extension ParserPrinter {
 /// Use `AnyParserPrinter` to wrap a parser whose type has details you don't want to expose across
 /// API boundaries, such as different modules. When you use type erasure this way, you can change
 /// the underlying parser over time without affecting existing clients.
+@preconcurrency // Don't know if this could ever be removed, maybe with a new type AnySendableParserPrinter?
 public struct AnyParserPrinter<Input, Output>: ParserPrinter {
   @usableFromInline let parser: (inout Input) throws -> Output
   @usableFromInline let printer: (Output, inout Input) throws -> Void

--- a/Sources/Parsing/ParserPrinters/Backtracking.swift
+++ b/Sources/Parsing/ParserPrinters/Backtracking.swift
@@ -29,3 +29,5 @@ extension Backtracking: ParserPrinter where Upstream: ParserPrinter {
     try self.upstream.print(output, into: &input)
   }
 }
+
+extension Backtracking: Sendable where Upstream: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Bool.swift
+++ b/Sources/Parsing/ParserPrinters/Bool.swift
@@ -21,7 +21,7 @@ extension Parsers {
   /// `Bool.parser()`, which constructs this type.
   ///
   /// See <doc:Bool> for more information about this parser.
-  public struct BoolParser<Input: Collection>: Parser
+  public struct BoolParser<Input: Collection>: Parser, Sendable
   where
     Input.SubSequence == Input,
     Input.Element == UTF8.CodeUnit

--- a/Sources/Parsing/ParserPrinters/CaseIterableRawRepresentable.swift
+++ b/Sources/Parsing/ParserPrinters/CaseIterableRawRepresentable.swift
@@ -101,6 +101,8 @@ extension CaseIterable where Self: RawRepresentable, RawValue == String {
 }
 
 extension Parsers {
+  
+  @preconcurrency // Should be Sendable when toPrefix and areEquivalent are Sendable
   public struct CaseIterableRawRepresentableParser<
     Input: Collection, Output: CaseIterable & RawRepresentable, Prefix: Collection
   >: Parser

--- a/Sources/Parsing/ParserPrinters/Conditional.swift
+++ b/Sources/Parsing/ParserPrinters/Conditional.swift
@@ -63,3 +63,5 @@ where
     }
   }
 }
+
+extension Parsers.Conditional: Sendable where First: Sendable, Second: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Consumed.swift
+++ b/Sources/Parsing/ParserPrinters/Consumed.swift
@@ -31,3 +31,5 @@ extension Consumed: ParserPrinter where Upstream.Input: PrependableCollection {
     }
   }
 }
+
+extension Consumed: Sendable where Upstream: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Digits.swift
+++ b/Sources/Parsing/ParserPrinters/Digits.swift
@@ -188,3 +188,5 @@ extension Digits where InputToBytes == Conversions.Identity<Substring.UTF8View> 
     self.init(length)
   }
 }
+
+extension Digits: Sendable where Length: Sendable, InputToBytes: Sendable { }

--- a/Sources/Parsing/ParserPrinters/End.swift
+++ b/Sources/Parsing/ParserPrinters/End.swift
@@ -16,7 +16,7 @@
 ///
 /// > Note: This parser is automatically inserted when you invoke the non-incremental
 /// > ``Parser/parse(_:)-6h1d0`` and ``Parser/parse(_:)-2wzcq`` methods.
-public struct End<Input: Sequence>: ParserPrinter {
+public struct End<Input: Sequence>: ParserPrinter, Sendable {
   @inlinable
   public init() {}
 

--- a/Sources/Parsing/ParserPrinters/Fail.swift
+++ b/Sources/Parsing/ParserPrinters/Fail.swift
@@ -27,13 +27,13 @@
 /// ```
 public struct Fail<Input, Output>: ParserPrinter {
   @usableFromInline
-  let error: Error
+  let error: any Error
 
   /// Creates a parser that throws an error when it runs.
   ///
   /// - Parameter error: An error to throw when the parser is run.
   @inlinable
-  public init(throwing error: Error) {
+  public init(throwing error: any Error) {
     self.error = error
   }
 

--- a/Sources/Parsing/ParserPrinters/Fail.swift
+++ b/Sources/Parsing/ParserPrinters/Fail.swift
@@ -25,7 +25,7 @@
 /// // 1 | 123
 /// //   | ^^^
 /// ```
-public struct Fail<Input, Output>: ParserPrinter {
+public struct Fail<Input, Output>: ParserPrinter, Sendable {
   @usableFromInline
   let error: any Error
 

--- a/Sources/Parsing/ParserPrinters/First.swift
+++ b/Sources/Parsing/ParserPrinters/First.swift
@@ -21,7 +21,7 @@
 /// // 1 |
 /// //   | ^ expected element
 /// ```
-public struct First<Input: Collection>: Parser where Input.SubSequence == Input {
+public struct First<Input: Collection>: Parser, Sendable where Input.SubSequence == Input {
   @inlinable
   public init() {}
 

--- a/Sources/Parsing/ParserPrinters/Float.swift
+++ b/Sources/Parsing/ParserPrinters/Float.swift
@@ -24,7 +24,7 @@ extension Parsers {
   /// `Double.parser()`, `Float80.parser()`, etc., all of which construct this type.
   ///
   /// See <doc:Float> for more information about this parser.
-  public struct FloatParser<Input: Collection, Output: BinaryFloatingPoint>: Parser
+  public struct FloatParser<Input: Collection, Output: BinaryFloatingPoint>: Parser, Sendable
   where
     Input.SubSequence == Input,
     Input.Element == UTF8.CodeUnit,

--- a/Sources/Parsing/ParserPrinters/From.swift
+++ b/Sources/Parsing/ParserPrinters/From.swift
@@ -30,9 +30,11 @@ extension From: ParserPrinter where Downstream: ParserPrinter {
   }
 }
 
+extension From: Sendable where Upstream: Sendable, Downstream: Sendable { }
+
 // TODO: Do we want to ship this?
 extension Parsers {
-  public struct Identity<InputOutput>: ParserPrinter {
+  public struct Identity<InputOutput>: ParserPrinter, Sendable {
     @usableFromInline
     init() {}
 

--- a/Sources/Parsing/ParserPrinters/Int.swift
+++ b/Sources/Parsing/ParserPrinters/Int.swift
@@ -28,7 +28,7 @@ extension Parsers {
   /// `UInt8.parser()`, etc., all of which construct this type.
   ///
   /// See <doc:Int> for more information about this parser.
-  public struct IntParser<Input: Collection, Output: FixedWidthInteger>: Parser
+  public struct IntParser<Input: Collection, Output: FixedWidthInteger>: Parser, Sendable
   where
     Input.SubSequence == Input,
     Input.Element == UTF8.CodeUnit

--- a/Sources/Parsing/ParserPrinters/Many.swift
+++ b/Sources/Parsing/ParserPrinters/Many.swift
@@ -95,7 +95,7 @@ where
     var previous = input
     var result = self.initialResult
     var count = 0
-    var loopError: Error?
+    var loopError: (any Error)?
     while self.maximum.map({ count < $0 }) ?? true {
       let output: Element.Output
       do {

--- a/Sources/Parsing/ParserPrinters/Many.swift
+++ b/Sources/Parsing/ParserPrinters/Many.swift
@@ -74,6 +74,7 @@ import Foundation
 /// // 1 | 1,2,Hello---
 /// //   |     ^ expected integer
 /// ```
+@preconcurrency
 public struct Many<
   Input, Element: Parser, Result, Separator: Parser, Terminator: Parser, Printability
 >: Parser

--- a/Sources/Parsing/ParserPrinters/Many.swift
+++ b/Sources/Parsing/ParserPrinters/Many.swift
@@ -1,3 +1,5 @@
+// TODO: Audit for Sendability
+
 import Foundation
 
 /// A parser that attempts to run another parser as many times as specified, accumulating the result

--- a/Sources/Parsing/ParserPrinters/Map.swift
+++ b/Sources/Parsing/ParserPrinters/Map.swift
@@ -74,6 +74,7 @@ extension Parsers {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Parser/map(_:)-4hsj5`` operation, which constructs this type.
+  @preconcurrency // Can be sendable when Upstream and transform are Sendable
   public struct Map<Upstream: Parser, NewOutput>: Parser {
     /// The parser from which this parser receives output.
     public let upstream: Upstream

--- a/Sources/Parsing/ParserPrinters/Map.swift
+++ b/Sources/Parsing/ParserPrinters/Map.swift
@@ -13,9 +13,9 @@ extension Parser {
   /// - Parameter transform: A closure that transforms values of this parser's output.
   /// - Returns: A parser of transformed outputs.
   @_disfavoredOverload
-  @inlinable @preconcurrency
+  @inlinable
   public func map<NewOutput>(
-    _ transform: @Sendable @escaping (Output) -> NewOutput
+    _ transform: @escaping (Output) -> NewOutput
   ) -> Parsers.Map<Self, NewOutput> {
     .init(upstream: self, transform: transform)
   }
@@ -72,15 +72,16 @@ extension Parsers {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Parser/map(_:)-4hsj5`` operation, which constructs this type.
+  @preconcurrency
   public struct Map<Upstream: Parser, NewOutput>: Parser {
     /// The parser from which this parser receives output.
     public let upstream: Upstream
 
     /// The closure that transforms output from the upstream parser.
-    public let transform: @Sendable (Upstream.Output) -> NewOutput
+    public let transform: (Upstream.Output) -> NewOutput
 
-    @inlinable @preconcurrency
-    public init(upstream: Upstream, transform: @Sendable @escaping (Upstream.Output) -> NewOutput) {
+    @inlinable
+    public init(upstream: Upstream, transform: @escaping (Upstream.Output) -> NewOutput) {
       self.upstream = upstream
       self.transform = transform
     }
@@ -157,6 +158,6 @@ extension Parsers.MapConstant: ParserPrinter where Upstream: ParserPrinter, Outp
   }
 }
 
-extension Parsers.Map: Sendable where Upstream: Sendable { } // TODO: Language does not support checking if a closure is Sendable.
+//extension Parsers.Map: Sendable where Upstream: Sendable { } // TODO: Language does not support checking if a closure is Sendable.
 extension Parsers.MapConstant: Sendable where Upstream: Sendable, Output: Sendable { }
 extension Parsers.MapConversion: Sendable where Upstream: Sendable, Downstream: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Map.swift
+++ b/Sources/Parsing/ParserPrinters/Map.swift
@@ -1,3 +1,5 @@
+// TODO: Audit for Sendability
+
 extension Parser {
   /// Returns a parser that transforms the output of this parser with a given closure.
   ///

--- a/Sources/Parsing/ParserPrinters/Not.swift
+++ b/Sources/Parsing/ParserPrinters/Not.swift
@@ -57,3 +57,5 @@ public struct Not<Input, Upstream: Parser>: ParserPrinter where Upstream.Input =
     )
   }
 }
+
+extension Not: Sendable where Upstream: Sendable { }

--- a/Sources/Parsing/ParserPrinters/OneOf.swift
+++ b/Sources/Parsing/ParserPrinters/OneOf.swift
@@ -181,3 +181,5 @@ extension OneOf: ParserPrinter where Parsers: ParserPrinter {
     try self.parsers.print(output, into: &input)
   }
 }
+
+extension OneOf: Sendable where Parsers: Sendable { }

--- a/Sources/Parsing/ParserPrinters/OneOfMany.swift
+++ b/Sources/Parsing/ParserPrinters/OneOfMany.swift
@@ -30,7 +30,7 @@ extension Parsers {
     public func parse(_ input: inout Parsers.Input) throws -> Parsers.Output {
       let original = input
       var count = self.parsers.count
-      var errors: [Error] = []
+      var errors: [any Error] = []
       errors.reserveCapacity(count)
       for parser in self.parsers {
         do {
@@ -51,7 +51,7 @@ extension Parsers.OneOfMany: ParserPrinter where Parsers: ParserPrinter {
   public func print(_ output: Parsers.Output, into input: inout Parsers.Input) throws {
     let original = input
     var count = self.parsers.count
-    var errors: [Error] = []
+    var errors: [any Error] = []
     errors.reserveCapacity(count)
     for parser in self.parsers.reversed() {
       do {

--- a/Sources/Parsing/ParserPrinters/OneOfMany.swift
+++ b/Sources/Parsing/ParserPrinters/OneOfMany.swift
@@ -66,3 +66,5 @@ extension Parsers.OneOfMany: ParserPrinter where Parsers: ParserPrinter {
     throw PrintingError.manyFailed(errors, at: input)
   }
 }
+
+extension Parsers.OneOfMany: Sendable where Parsers: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Optional.swift
+++ b/Sources/Parsing/ParserPrinters/Optional.swift
@@ -50,3 +50,5 @@ extension Parsers.OptionalVoid: ParserPrinter where Wrapped: ParserPrinter {
     try self.wrapped?.print(into: &input)
   }
 }
+
+extension Parsers.OptionalVoid: Sendable where Wrapped: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Optionally.swift
+++ b/Sources/Parsing/ParserPrinters/Optionally.swift
@@ -59,3 +59,5 @@ extension Optionally: ParserPrinter where Wrapped: ParserPrinter {
     try self.wrapped.print(output, into: &input)
   }
 }
+
+extension Optionally: Sendable where Wrapped: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Parse.swift
+++ b/Sources/Parsing/ParserPrinters/Parse.swift
@@ -236,3 +236,5 @@ where Input == ParserPrinters.Input {
     try self.parserPrinters.print(output, into: &input)
   }
 }
+
+extension Parse: Sendable where Parsers: Sendable { }

--- a/Sources/Parsing/ParserPrinters/ParseableFormatStyle.swift
+++ b/Sources/Parsing/ParserPrinters/ParseableFormatStyle.swift
@@ -33,4 +33,7 @@
       input.prepend(contentsOf: self.style.format(output))
     }
   }
+
+  @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+  extension Formatted: Sendable where Style: Sendable { }
 #endif

--- a/Sources/Parsing/ParserPrinters/Peek.swift
+++ b/Sources/Parsing/ParserPrinters/Peek.swift
@@ -58,3 +58,5 @@ public struct Peek<Input, Upstream: Parser>: ParserPrinter where Upstream.Input 
     }
   }
 }
+
+extension Peek: Sendable where Upstream: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Pipe.swift
+++ b/Sources/Parsing/ParserPrinters/Pipe.swift
@@ -116,3 +116,5 @@ extension Parsers.PipeEnd: ParserPrinter {
     }
   }
 }
+
+extension Parsers.Pipe: Sendable where Upstream: Sendable, Downstream: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Prefix.swift
+++ b/Sources/Parsing/ParserPrinters/Prefix.swift
@@ -1,3 +1,5 @@
+// TODO: Audit for Sendability
+
 /// A parser that consumes a subsequence from the beginning of its input.
 ///
 /// This parser is named after `Sequence.prefix`, which it uses under the hood to consume a number

--- a/Sources/Parsing/ParserPrinters/PrefixThrough.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixThrough.swift
@@ -79,8 +79,8 @@ extension PrefixThrough: ParserPrinter where Input: PrependableCollection {
 
 extension PrefixThrough where Input.Element: Equatable {
   @inlinable
-  public init(_ possibleMatch: Input) where Input: Sendable {
-    self.init(possibleMatch) { $0 == $1 }
+  public init(_ possibleMatch: Input) {
+    self.init(possibleMatch, by: ==)
   }
 }
 

--- a/Sources/Parsing/ParserPrinters/PrefixThrough.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixThrough.swift
@@ -13,12 +13,12 @@
 /// ```
 public struct PrefixThrough<Input: Collection>: Parser where Input.SubSequence == Input {
   public let possibleMatch: Input
-  public let areEquivalent: (Input.Element, Input.Element) -> Bool
+  public let areEquivalent: @Sendable (Input.Element, Input.Element) -> Bool
 
   @inlinable
   public init(
     _ possibleMatch: Input,
-    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
+    by areEquivalent: @Sendable @escaping (Input.Element, Input.Element) -> Bool
   ) {
     self.possibleMatch = possibleMatch
     self.areEquivalent = areEquivalent
@@ -78,8 +78,8 @@ extension PrefixThrough: ParserPrinter where Input: PrependableCollection {
 
 extension PrefixThrough where Input.Element: Equatable {
   @inlinable
-  public init(_ possibleMatch: Input) {
-    self.init(possibleMatch, by: ==)
+  public init(_ possibleMatch: Input) where Input: Sendable {
+    self.init(possibleMatch) { $0 == $1 }
   }
 }
 
@@ -88,7 +88,7 @@ extension PrefixThrough where Input == Substring {
   @inlinable
   public init(
     _ possibleMatch: String,
-    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)
+    by areEquivalent: @Sendable @escaping (Input.Element, Input.Element) -> Bool = { $0 == $1 } // Operator sugar not sendable by default
   ) {
     self.init(possibleMatch[...], by: areEquivalent)
   }
@@ -99,7 +99,7 @@ extension PrefixThrough where Input == Substring.UTF8View {
   @inlinable
   public init(
     _ possibleMatch: String.UTF8View,
-    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)
+    by areEquivalent: @Sendable @escaping (Input.Element, Input.Element) -> Bool = { $0 == $1 }
   ) {
     self.init(String(possibleMatch)[...].utf8, by: areEquivalent)
   }
@@ -108,3 +108,5 @@ extension PrefixThrough where Input == Substring.UTF8View {
 extension Parsers {
   public typealias PrefixThrough = Parsing.PrefixThrough  // NB: Convenience type alias for discovery
 }
+
+extension PrefixThrough: Sendable where Input: Sendable { }

--- a/Sources/Parsing/ParserPrinters/PrefixThrough.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixThrough.swift
@@ -11,14 +11,15 @@
 /// try line.parse(&input)  // "Hello\n"
 /// input                   // "world\n"
 /// ```
+@preconcurrency
 public struct PrefixThrough<Input: Collection>: Parser where Input.SubSequence == Input {
   public let possibleMatch: Input
-  public let areEquivalent: @Sendable (Input.Element, Input.Element) -> Bool
+  public let areEquivalent: (Input.Element, Input.Element) -> Bool
 
   @inlinable
   public init(
     _ possibleMatch: Input,
-    by areEquivalent: @Sendable @escaping (Input.Element, Input.Element) -> Bool
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool
   ) {
     self.possibleMatch = possibleMatch
     self.areEquivalent = areEquivalent
@@ -88,7 +89,7 @@ extension PrefixThrough where Input == Substring {
   @inlinable
   public init(
     _ possibleMatch: String,
-    by areEquivalent: @Sendable @escaping (Input.Element, Input.Element) -> Bool = { $0 == $1 } // Operator sugar not sendable by default
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)
   ) {
     self.init(possibleMatch[...], by: areEquivalent)
   }
@@ -99,7 +100,7 @@ extension PrefixThrough where Input == Substring.UTF8View {
   @inlinable
   public init(
     _ possibleMatch: String.UTF8View,
-    by areEquivalent: @Sendable @escaping (Input.Element, Input.Element) -> Bool = { $0 == $1 }
+    by areEquivalent: @escaping (Input.Element, Input.Element) -> Bool = (==)
   ) {
     self.init(String(possibleMatch)[...].utf8, by: areEquivalent)
   }
@@ -108,5 +109,3 @@ extension PrefixThrough where Input == Substring.UTF8View {
 extension Parsers {
   public typealias PrefixThrough = Parsing.PrefixThrough  // NB: Convenience type alias for discovery
 }
-
-extension PrefixThrough: Sendable where Input: Sendable { }

--- a/Sources/Parsing/ParserPrinters/PrefixUpTo.swift
+++ b/Sources/Parsing/ParserPrinters/PrefixUpTo.swift
@@ -11,6 +11,7 @@
 /// try line.parse(&input)  // "Hello"
 /// input                   // "\nworld\n"
 /// ```
+@preconcurrency
 public struct PrefixUpTo<Input: Collection>: Parser where Input.SubSequence == Input {
   public let possibleMatch: Input
   public let areEquivalent: (Input.Element, Input.Element) -> Bool

--- a/Sources/Parsing/ParserPrinters/Printing.swift
+++ b/Sources/Parsing/ParserPrinters/Printing.swift
@@ -71,7 +71,8 @@ extension Parsers {
       try self.printer.print(output, into: &input)
     }
   }
-
+  
+  @preconcurrency
   public struct Print<Upstream: Parser>: ParserPrinter {
     public let parser: Upstream
     public let printer: (Upstream.Output, inout Upstream.Input) -> Void
@@ -95,7 +96,8 @@ extension Parsers {
       self.printer(output, &input)
     }
   }
-
+  
+  @preconcurrency
   public struct TryPrint<Upstream: Parser>: ParserPrinter {
     public let parser: Upstream
     public let printer: (Upstream.Output, inout Upstream.Input) throws -> Void
@@ -120,3 +122,5 @@ extension Parsers {
     }
   }
 }
+
+extension Parsers.OverridePrinting: Sendable where Parser: Sendable, Printer: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Pullback.swift
+++ b/Sources/Parsing/ParserPrinters/Pullback.swift
@@ -33,6 +33,7 @@ extension Parsers {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Parser/pullback(_:)`` operator, which constructs this type.
+  @preconcurrency
   public struct Pullback<Downstream: Parser, Input>: Parser {
     public let downstream: Downstream
     public let keyPath: WritableKeyPath<Input, Downstream.Input>

--- a/Sources/Parsing/ParserPrinters/ReplaceError.swift
+++ b/Sources/Parsing/ParserPrinters/ReplaceError.swift
@@ -85,3 +85,5 @@ extension Parsers.ReplaceError: ParserPrinter where Upstream: ParserPrinter {
     }
   }
 }
+
+extension Parsers.ReplaceError: Sendable where Upstream: Sendable, Output: Sendable { }

--- a/Sources/Parsing/ParserPrinters/Rest.swift
+++ b/Sources/Parsing/ParserPrinters/Rest.swift
@@ -21,7 +21,7 @@
 /// If you want to allow for the possibility of an empty remaining input you can use the
 /// ``Optionally`` parser to parse an optional output value, or the ``replaceError(with:)`` method
 /// to coalesce the error into a default output value.
-public struct Rest<Input: Collection>: Parser where Input.SubSequence == Input {
+public struct Rest<Input: Collection>: Parser, Sendable where Input.SubSequence == Input {
   @inlinable
   public init() {}
 

--- a/Sources/Parsing/ParserPrinters/Skip.swift
+++ b/Sources/Parsing/ParserPrinters/Skip.swift
@@ -24,3 +24,5 @@ extension Skip: ParserPrinter where Parsers: ParserPrinter, Parsers.Output == Vo
 extension Parsers {
   public typealias Skip = Parsing.Skip  // NB: Convenience type alias for discovery
 }
+
+extension Skip: Sendable where Parsers: Sendable { }

--- a/Sources/Parsing/ParserPrinters/StartsWith.swift
+++ b/Sources/Parsing/ParserPrinters/StartsWith.swift
@@ -36,6 +36,7 @@
 /// try "Hello, ".parse(&input)  // ()
 /// input                        // "Blob!"
 /// ```
+@preconcurrency
 public struct StartsWith<Input: Collection>: Parser where Input.SubSequence == Input {
   public let count: Int
   public let possiblePrefix: AnyCollection<Input.Element>

--- a/Sources/Parsing/ParserPrinters/UUID.swift
+++ b/Sources/Parsing/ParserPrinters/UUID.swift
@@ -26,7 +26,7 @@ extension Parsers {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// `UUID.parser()`, which constructs this type.
-  public struct UUIDParser<Input: Collection>: Parser
+  public struct UUIDParser<Input: Collection>: Parser, Sendable
   where
     Input.SubSequence == Input,
     Input.Element == UTF8.CodeUnit

--- a/Sources/Parsing/ParserPrinters/Whitespace.swift
+++ b/Sources/Parsing/ParserPrinters/Whitespace.swift
@@ -7,7 +7,7 @@ where
   InputToBytes.Output.Element == UTF8.CodeUnit,
   InputToBytes.Output.SubSequence == InputToBytes.Output
 {
-  public enum Configuration {
+  public enum Configuration: Sendable {
     case all
     case horizontal
     case vertical
@@ -188,3 +188,5 @@ extension Whitespace {
 extension Parsers {
   public typealias Whitespace = Parsing.Whitespace  // NB: Convenience type alias for discovery
 }
+
+extension Whitespace: Sendable where Length: Sendable, InputToBytes: Sendable { }

--- a/Sources/Parsing/Parsers/AnyParser.swift
+++ b/Sources/Parsing/Parsers/AnyParser.swift
@@ -24,6 +24,7 @@ extension Parser {
 /// Use ``AnyParser`` to wrap a parser whose type has details you don't want to expose across API
 /// boundaries, such as different modules. When you use type erasure this way, you can change the
 /// underlying parser over time without affecting existing clients.
+@preconcurrency // May need a new type for AnySendableParser
 public struct AnyParser<Input, Output>: Parser {
   @usableFromInline
   let parser: (inout Input) throws -> Output

--- a/Sources/Parsing/Parsers/CompactMap.swift
+++ b/Sources/Parsing/Parsers/CompactMap.swift
@@ -54,6 +54,7 @@ extension Parsers {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Parser/compactMap(_:)`` operation, which constructs this type.
+  @preconcurrency
   public struct CompactMap<Upstream: Parser, Output>: Parser {
     public let upstream: Upstream
     public let transform: (Upstream.Output) -> Output?

--- a/Sources/Parsing/Parsers/FlatMap.swift
+++ b/Sources/Parsing/Parsers/FlatMap.swift
@@ -28,6 +28,7 @@ extension Parsers {
   ///
   /// You will not typically need to interact with this type directly. Instead you will usually use
   /// the ``Parser/flatMap(_:)`` operation, which constructs this type.
+  @preconcurrency
   public struct FlatMap<NewParser: Parser, Upstream: Parser>: Parser
   where NewParser.Input == Upstream.Input {
     public let upstream: Upstream

--- a/Sources/Parsing/Parsers/Stream.swift
+++ b/Sources/Parsing/Parsers/Stream.swift
@@ -54,3 +54,5 @@ where Parsers.Input == Input {
 extension Parsers {
   public typealias Stream = Parsing.Stream  // NB: Convenience type alias for discovery
 }
+
+extension Stream: Sendable where Parsers: Sendable { }

--- a/Sources/Parsing/ParsingError.swift
+++ b/Sources/Parsing/ParsingError.swift
@@ -111,7 +111,8 @@ enum ParsingError: Error {
       )
     }
   }
-
+  
+  @preconcurrency // TODO: Make this concurrency safe
   @usableFromInline
   struct Context {
     @usableFromInline

--- a/Sources/Parsing/ParsingError.swift
+++ b/Sources/Parsing/ParsingError.swift
@@ -3,7 +3,7 @@ import Foundation
 @usableFromInline
 enum ParsingError: Error {
   case failed(String, Context)
-  case manyFailed([Error], Context)
+  case manyFailed([any Error], Context)
 
   @usableFromInline
   static func expectedInput(_ description: String, at remainingInput: Any) -> Self {
@@ -48,12 +48,12 @@ enum ParsingError: Error {
   }
 
   @usableFromInline
-  static func manyFailed(_ errors: [Error], at remainingInput: Any) -> Self {
+  static func manyFailed(_ errors: [any Error], at remainingInput: Any) -> Self {
     .manyFailed(errors, .init(remainingInput: remainingInput, debugDescription: ""))
   }
 
   @usableFromInline
-  static func wrap(_ error: Error, from originalInput: Any, to remainingInput: Any) -> Self {
+  static func wrap(_ error: any Error, from originalInput: Any, to remainingInput: Any) -> Self {
     error as? ParsingError
       ?? .failed(
         "",
@@ -67,7 +67,7 @@ enum ParsingError: Error {
   }
 
   @usableFromInline
-  static func wrap(_ error: Error, at remainingInput: Any) -> Self {
+  static func wrap(_ error: any Error, at remainingInput: Any) -> Self {
     .wrap(error, from: remainingInput, to: remainingInput)
   }
 
@@ -81,7 +81,7 @@ enum ParsingError: Error {
 
   @usableFromInline
   func flattened() -> Self {
-    func flatten(_ depth: Int = 0) -> (Error) -> [(depth: Int, error: Error)] {
+    func flatten(_ depth: Int = 0) -> (any Error) -> [(depth: Int, error: any Error)] {
       { error in
         switch error {
         case let ParsingError.manyFailed(errors, _):
@@ -124,14 +124,14 @@ enum ParsingError: Error {
     var remainingInput: Any
 
     @usableFromInline
-    var underlyingError: Error?
+    var underlyingError: (any Error)?
 
     @usableFromInline
     init(
       originalInput: Any,
       remainingInput: Any,
       debugDescription: String,
-      underlyingError: Error? = nil
+      underlyingError: (any Error)? = nil
     ) {
       self.originalInput = originalInput
       self.remainingInput = remainingInput
@@ -143,7 +143,7 @@ enum ParsingError: Error {
     init(
       remainingInput: Any,
       debugDescription: String,
-      underlyingError: Error? = nil
+      underlyingError: (any Error)? = nil
     ) {
       self.originalInput = remainingInput
       self.remainingInput = remainingInput
@@ -168,8 +168,8 @@ extension ParsingError: CustomDebugStringConvertible {
     }
   }
 
-  fileprivate func debugDescription(for errors: [Error]) -> String {
-    func failed(_ error: Error) -> (String, Context)? {
+  fileprivate func debugDescription(for errors: [any Error]) -> String {
+    func failed(_ error: any Error) -> (String, Context)? {
       guard
         let error = error as? ParsingError,
         case .failed(let label, let context) = error
@@ -380,12 +380,12 @@ func format(labels: [String], context: ParsingError.Context) -> String {
   return formatHelp(from: context.originalInput, to: context.remainingInput)
 }
 
-private func formatError(_ error: Error) -> String {
+private func formatError(_ error: any Error) -> String {
   switch error {
   case let error as ParsingError:
     return error.debugDescription
 
-  case let error as LocalizedError:
+  case let error as any LocalizedError:
     return error.localizedDescription
 
   default:

--- a/Sources/Parsing/PrintingError.swift
+++ b/Sources/Parsing/PrintingError.swift
@@ -1,7 +1,7 @@
 @usableFromInline
 enum PrintingError: Error {
   case failed(Context)
-  case manyFailed([Error], Context)
+  case manyFailed([any Error], Context)
 
   @available(*, deprecated)
   @usableFromInline
@@ -15,7 +15,7 @@ enum PrintingError: Error {
   }
 
   @usableFromInline
-  static func manyFailed(_ errors: [Error], at input: Any) -> Self {
+  static func manyFailed(_ errors: [any Error], at input: Any) -> Self {
     .manyFailed(errors, .init(input: input, debugDescription: ""))
   }
 
@@ -29,7 +29,7 @@ enum PrintingError: Error {
 
   @usableFromInline
   func flattened() -> Self {
-    func flatten(_ depth: Int = 0) -> (Error) -> [(depth: Int, error: Error)] {
+    func flatten(_ depth: Int = 0) -> (any Error) -> [(depth: Int, error: any Error)] {
       { error in
         switch error {
         case let PrintingError.manyFailed(errors, _):
@@ -69,13 +69,13 @@ enum PrintingError: Error {
     var input: Any
 
     @usableFromInline
-    var underlyingError: Error?
+    var underlyingError: (any Error)?
 
     @usableFromInline
     init(
       input: Any,
       debugDescription: String,
-      underlyingError: Error? = nil
+      underlyingError: (any Error)? = nil
     ) {
       self.input = input
       self.debugDescription = debugDescription

--- a/Sources/Parsing/PrintingError.swift
+++ b/Sources/Parsing/PrintingError.swift
@@ -59,7 +59,8 @@ enum PrintingError: Error {
       )
     }
   }
-
+  
+  @preconcurrency // TODO: Make this concurrency safe
   @usableFromInline
   struct Context {
     @usableFromInline

--- a/Sources/swift-parsing-benchmark/Arithmetic.swift
+++ b/Sources/swift-parsing-benchmark/Arithmetic.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/BinaryData.swift
+++ b/Sources/swift-parsing-benchmark/BinaryData.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/Bool.swift
+++ b/Sources/swift-parsing-benchmark/Bool.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/CSV.swift
+++ b/Sources/swift-parsing-benchmark/CSV.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/Color.swift
+++ b/Sources/swift-parsing-benchmark/Color.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Parsing
 
 /// This benchmark demonstrates how to parse a hexadecimal color.

--- a/Sources/swift-parsing-benchmark/Common/Benchmarking.swift
+++ b/Sources/swift-parsing-benchmark/Common/Benchmarking.swift
@@ -15,7 +15,7 @@ extension BenchmarkSuite {
 
 struct Benchmarking: AnyBenchmark {
   let name: String
-  let settings: [BenchmarkSetting] = []
+  let settings: [any BenchmarkSetting] = []
   private let _run: () throws -> Void
   private let _setUp: () -> Void
   private let _tearDown: () -> Void

--- a/Sources/swift-parsing-benchmark/Date.swift
+++ b/Sources/swift-parsing-benchmark/Date.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/HTTP.swift
+++ b/Sources/swift-parsing-benchmark/HTTP.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Parsing
 
 /// This benchmark reproduces an HTTP parser from [a Rust parser benchmark suite][rust-parser].

--- a/Sources/swift-parsing-benchmark/JSON.swift
+++ b/Sources/swift-parsing-benchmark/JSON.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/Numerics.swift
+++ b/Sources/swift-parsing-benchmark/Numerics.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/PrefixUpTo.swift
+++ b/Sources/swift-parsing-benchmark/PrefixUpTo.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/Race.swift
+++ b/Sources/swift-parsing-benchmark/Race.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Parsing
 
 /// This benchmark implements a parser for a custom format covered in

--- a/Sources/swift-parsing-benchmark/ReadmeExample.swift
+++ b/Sources/swift-parsing-benchmark/ReadmeExample.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 
@@ -29,7 +29,7 @@ let readmeExampleSuite = BenchmarkSuite(name: "README Example") { suite in
           Parse(User.init(id:name:isAdmin:)) {
             Int.parser()
             ","
-            Prefix { $0 != "," }.map(String.init)
+            Prefix { $0 != "," }.map(String.init) // Can't use String.init if map expects a @Sendable closure directly, or compiler will emit a warning.
             ","
             Bool.parser()
           }

--- a/Sources/swift-parsing-benchmark/StringAbstractions.swift
+++ b/Sources/swift-parsing-benchmark/StringAbstractions.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Parsing
 
 /// This benchmark demonstrates how to parse on multiple string abstractions at once, and the costs

--- a/Sources/swift-parsing-benchmark/UUID.swift
+++ b/Sources/swift-parsing-benchmark/UUID.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Foundation
 import Parsing
 

--- a/Sources/swift-parsing-benchmark/XCTestLogs.swift
+++ b/Sources/swift-parsing-benchmark/XCTestLogs.swift
@@ -1,4 +1,4 @@
-import Benchmark
+@preconcurrency import Benchmark
 import Parsing
 
 /// This benchmark demonstrates how to build process a dump of Xcode test logs to transform them

--- a/Tests/Swift6Tests/SendableTests.swift
+++ b/Tests/Swift6Tests/SendableTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+import Foundation
+import Parsing
+
+final class SendableTests: XCTestCase {
+
+}
+
+enum GlobalParsers {
+  
+  static let wordParser: some Parser<Substring, [Substring]> = Parse {
+    Many {
+      CharacterSet.letters
+    } separator: {
+      ","
+    }
+  }
+  
+}
+ 

--- a/Tests/Swift6Tests/SendableTests.swift
+++ b/Tests/Swift6Tests/SendableTests.swift
@@ -3,13 +3,21 @@ import XCTest
 import Foundation
 import Parsing
 
-final class SendableTests: XCTestCase {
-
+nonisolated final class SendableTests: XCTestCase {
+  
+  func testGlobalParser() throws {
+    var test: Substring = "this,is,a,word,list"
+    let expected: [Substring] = ["this", "is", "a", "word", "list"]
+    
+    let result = try GlobalParsers.wordParser.parse(&test)
+    XCTAssertEqual(result, expected)
+  }
+  
 }
 
 enum GlobalParsers {
   
-  static let wordParser: some Parser<Substring, [Substring]> = Parse {
+  static let wordParser: some Parser<Substring, [Substring]> & Sendable = Parse {
     Many {
       CharacterSet.letters
     } separator: {

--- a/Tests/Swift6Tests/SendableTests.swift
+++ b/Tests/Swift6Tests/SendableTests.swift
@@ -25,5 +25,19 @@ enum GlobalParsers {
     }
   }
   
+  static let mapParser: some Parser<Substring, Int> & Sendable = Parse {
+    let ns = NotSendable()
+    Int.parser()
+      .map { n in
+//        let capture = ns // Should be a warning in Swift 6, not an error
+        return n * 2
+      }
+  }
+  
 }
+
+class NotSendable { }
+
+@available(*, unavailable)
+extension NotSendable: Sendable { }
  

--- a/Tests/Swift6Tests/SendableTests.swift
+++ b/Tests/Swift6Tests/SendableTests.swift
@@ -9,7 +9,15 @@ nonisolated final class SendableTests: XCTestCase {
     var test: Substring = "this,is,a,word,list"
     let expected: [Substring] = ["this", "is", "a", "word", "list"]
     
-    let result = try GlobalParsers.wordParser.parse(&test)
+    let result: [Substring] = try GlobalParsers.wordParser.parse(&test)
+    XCTAssertEqual(result, expected)
+  }
+
+  func testGlobalParserWithTransformClosure() throws {
+    var test: Substring = "67"
+    let expected: Int = 134
+
+    let result: Int = try GlobalParsers.mapParser.parse(&test)
     XCTAssertEqual(result, expected)
   }
   
@@ -29,7 +37,7 @@ enum GlobalParsers {
     let ns = NotSendable()
     Int.parser()
       .map { n in
-//        let capture = ns // Should be a warning in Swift 6, not an error
+        // let capture = ns // Should be a warning in Swift 6, not an error
         return n * 2
       }
   }

--- a/Tests/Swift6Tests/SendableTests.swift
+++ b/Tests/Swift6Tests/SendableTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import Foundation
 import Parsing
 
-nonisolated final class SendableTests: XCTestCase {
+/* nonisolated */ final class SendableTests: XCTestCase {
   
   func testGlobalParser() throws {
     var test: Substring = "this,is,a,word,list"


### PR DESCRIPTION
## Motivation
Using the Swift 6 language mode in conjunction the Parsing package requires adding ``@preconcurrency`` to all import statements to suppress errors related to concurrency, especially global parsers using ``static let``.

## Changes
- Enabled [``StrictConcurrency``](https://www.swift.org/documentation/concurrency), [``ExistentialAny``](https://docs.swift.org/compiler/documentation/diagnostics/existential-any) and [``MemberImportVisibility``](https://docs.swift.org/compiler/documentation/diagnostics/member-import-visibility/) on all targets
- Added a new target ``Swift6Tests`` for testing changes due to migration.
- Added Sendable to concrete Parsers and Conversions that can be Sendable
- Added conditional Sendable to Parsers and Conversions that take other parsers
- Added ``@preconcurrency`` to Parsers that have **transform** closures (e.g. ``Map``)
- Added ``@preconcurrency`` to ``ParsingError.Context`` and ``PrintingError.Context``
- Adopted [``ExistentialAny``](https://docs.swift.org/compiler/documentation/diagnostics/existential-any) to   ``protocol`` types.

## Future Directions
- Parsers that have transform closures can and should be marked ``Sendable``, as long as the transform closure is ``Sendable``. Currently this can be done with ``@Sendable`` but this makes the closure **always** ``@Sendable``, which affects source compatibility. If there was a way to mark a type as ``Sendable`` when one of its closures are ``Sendable``, this would be ideal.
    - We could also just mark the transform closures always ``@Sendable``. Even though this is a reasonable assumption for most parsers, this may not apply to some clients.
        - If we mark those ``Parser`` ``init``s  with ``@preconcurrency``, the closure's Sendability will only be checked if the client has ``StrictConcurrency`` or Swift 6 enabled, and only a warning will be generated if it is violated.
    - The cleaner syntax where an ``init`` is provided as a transform (i.e. ``.map(String.init)``) doesn't work if the transform closure is marked as ``@Sendable``, since Swift complains that the``init`` is not ``@Sendable``. This can be worked around by wrapping the ``init`` in another closure (i.e. ``.map { String.init($0) }``)