### PR TITLE
Add SPI documentation target

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+  - documentation_targets: [Parsing]

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Xcode Logs.Parser                             4511625.500 ns ±   0.58 %        
 The documentation for releases and main are available here:
 
 * [main][swift-parsing-docs]
-* [0.10.0](https://pointfreeco.github.io/swift-parsing/0.10.0/documentation/parsing)
+* [0.10.0](https://swiftpackageindex.com/pointfreeco/swift-parsing/0.10.0/documentation/parsing)
 <details>
   <summary>
   Other versions
@@ -395,7 +395,7 @@ The printing functionality in this library is inspired by the paper ["Invertible
 
 This library is released under the MIT license. See [LICENSE](LICENSE) for details.
 
-[getting-started-docs]: https://pointfreeco.github.io/swift-parsing/main/documentation/parsing/gettingstarted
-[string-abstractions-docs]: https://pointfreeco.github.io/swift-parsing/main/documentation/parsing/stringabstractions
-[swift-parsing-docs]: https://pointfreeco.github.io/swift-parsing
+[getting-started-docs]: https://swiftpackageindex.com/pointfreeco/swift-parsing/main/documentation/parsing/gettingstarted
+[string-abstractions-docs]: https://swiftpackageindex.com/pointfreeco/swift-parsing/main/documentation/parsing/stringabstractions
+[swift-parsing-docs]: https://swiftpackageindex.com/pointfreeco/swift-parsing/main/documentation/parsing
 [swift-url-routing]: https://github.com/pointfreeco/swift-url-routing


### PR DESCRIPTION
## Summary
- Restore SPI configuration for the Parsing documentation target.
- Update current README documentation links to Swift Package Index URLs.
- Move the 0.10.0 documentation link to its matching Swift Package Index URL.

## Notes
Older README release links still point to the existing GitHub Pages documentation because their Swift Package Index equivalents return 404.

## Verification
- Confirmed SPI URLs for main, Getting Started, String Abstractions, and 0.10.0 resolve.
- Confirmed no pointfreeco.github.io main links remain in the repo.
- Ran git diff --check.